### PR TITLE
fixed storybook - wrong file path

### DIFF
--- a/src/stories/CodeFeed/ExploreOrg/index.stories.jsx
+++ b/src/stories/CodeFeed/ExploreOrg/index.stories.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { MemoryRouter } from "react-router";
-import ExploreOrg from "../../../components/MyFeed/ExploreOrgs";
+import ExploreOrg from "../../../components/MyFeed/discoverOrgs/OrgExplore";
 import ProviderWrapper from "../../../helpers/providerWrapper";
 
 export default {


### PR DESCRIPTION
1. Go to 'Codelabz-final/src/stories/CodeFeed/ExploreOrg/index.stories.jsx'


**Expected behavior**
Change the path to 
```
import ExploreOrg from "../../../components/MyFeed/discoverOrgs/OrgExplore";
```

<img width="1450" alt="Screenshot 2024-02-05 at 2 14 48 AM" src="https://github.com/c2siorg/Codelabz/assets/119070053/aee2efb4-08cd-4daf-ab94-8f904875eb99">


<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<img width="1792" alt="Screenshot 2024-02-05 at 8 18 07 PM" src="https://github.com/c2siorg/Codelabz/assets/119070053/9d8e2e29-97cd-49ae-a3e3-86a13f8d8856">

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots or GIF (In case of UI changes):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
