### PR TITLE
redirecting to /tutorials page after publishing or unpublishing the tutorial

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,11 +1,17 @@
 {
   "functions": {
-    "predeploy": ["npm --prefix \"$RESOURCE_DIR\" run lint"],
+    "predeploy": [
+      "npm --prefix \"$RESOURCE_DIR\" run lint"
+    ],
     "source": "functions"
   },
   "hosting": {
     "public": "build",
-    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"]
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**"
+    ]
   },
   "emulators": {
     "functions": {
@@ -38,7 +44,8 @@
     "storage": {
       "port": 9199,
       "host": "127.0.0.1"
-    }
+    },
+    "singleProjectMode": true
   },
   "storage": {
     "rules": "storage.rules"

--- a/src/components/Tutorials/subComps/EditControls.jsx
+++ b/src/components/Tutorials/subComps/EditControls.jsx
@@ -22,6 +22,7 @@ import { useDispatch } from "react-redux";
 import RemoveStepModal from "./RemoveStepModal";
 import ColorPickerModal from "./ColorPickerModal";
 import { Box, Stack } from "@mui/system";
+import { Link } from "react-router-dom";
 
 const EditControls = ({
   isPublished,
@@ -192,6 +193,8 @@ const EditControls = ({
                   <FileCopyIcon /> Preview mode
                 </Button>
               )}
+              {/* redirecting to /tutorials page */}
+              <Link to="/tutorials">
               <Button
                 data-testid="publishTutorial"
                 onClick={handlePublishTutorial}
@@ -200,6 +203,7 @@ const EditControls = ({
               >
                 <FileCopyIcon /> {isPublished ? "Unpublish" : "Publish"}
               </Button>
+              </Link>
               <DropdownMenu key="more" />
             </>
           )}


### PR DESCRIPTION

## Description
The changes in this pull request leads to redirecting to /tutorials page after someone publishes or unpublishes the tutorial for better user experience.

## Related Issue
issue #37 

## Video of changes made

https://github.com/c2siorg/Codelabz/assets/113119934/424ced9a-9ecd-4356-a537-5af34bb843da



