### PR TITLE
[ Feat : Loading of Dynamic Contributors Section in Home Page ]

### DIFF
--- a/src/components/CardTabs/Users/UserElement.jsx
+++ b/src/components/CardTabs/Users/UserElement.jsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import Box from "@mui/material/Box";
 import AddUser from "../../../assets/images/add-user.svg";
 import CheckUser from "../../../assets/images/square-check-regular.svg";
+import OrgUser from "../../../assets/images/org-user.svg";
 
 const UserElement = ({ user, index, useStyles }) => {
   const classes = useStyles();
@@ -26,7 +27,7 @@ const UserElement = ({ user, index, useStyles }) => {
         }}
       >
         <img
-          src={user.img[0]}
+          src={user?.img || OrgUser}
           className={classes.userImg}
           data-testId={index == 0 ? "UsersCardImg" : ""}
         />
@@ -35,13 +36,13 @@ const UserElement = ({ user, index, useStyles }) => {
             sx={{ fontWeight: 600, fontSize: "1rem" }}
             data-testId={index == 0 ? "UserName" : ""}
           >
-            {user.name}
+            {user?.name}
           </Box>
           <Box
             sx={{ fontWeight: 400, fontSize: "0.8rem" }}
             data-testId={index == 0 ? "UserDesg" : ""}
           >
-            {user.desg}
+            {user?.desg}
           </Box>
         </Box>
       </Box>

--- a/src/components/HomePage/index.jsx
+++ b/src/components/HomePage/index.jsx
@@ -37,6 +37,7 @@ import {
   getTutorialFeedData,
   getTutorialFeedIdArray
 } from "../../store/actions/tutorialPageActions";
+import { getOrgUserData } from "../../store/actions";
 
 function HomePage({ background = "white", textColor = "black" }) {
   const classes = useStyles();
@@ -137,32 +138,37 @@ function HomePage({ background = "white", textColor = "black" }) {
     }
   ]);
 
-  const [contributors, setContributors] = useState([
-    {
-      name: "Janvi Thakkar",
-      img: [OrgUser],
-      desg: "Software Engineer",
-      onClick: {}
-    },
-    {
-      name: "Janvi Thakkar",
-      img: [OrgUser],
-      desg: "Software Engineer",
-      onClick: {}
-    },
-    {
-      name: "Janvi Thakkar",
-      img: [OrgUser],
-      desg: "Software Engineer",
-      onClick: {}
-    },
-    {
-      name: "Janvi Thakkar",
-      img: [OrgUser],
-      desg: "Software Engineer",
-      onClick: {}
-    }
-  ]);
+  const [contributors, setContributors] = useState([]);
+  const data = useSelector(
+    ({
+      org: {
+        user: { data }
+      }
+    }) => data
+  );
+  const currentOrgHandle = useSelector(
+    ({
+      org: {
+        general: { current }
+      }
+    }) => current
+  );
+  useEffect(() => {
+    getOrgUserData(currentOrgHandle)(firestore, dispatch);
+  }, [currentOrgHandle, firestore, dispatch]);
+
+  useEffect(() => {
+    setContributors(data);
+    console.log("Data:", data);
+  }, [data]);
+  // const [contributors, setContributors] = useState([
+  //   {
+  //     name: "Janvi Thakkar",
+  //     img: [OrgUser],
+  //     desg: "Software Engineer",
+  //     onClick: {}
+  //   },
+  // ]);
 
   const profileData = useSelector(({ firebase: { profile } }) => profile);
   useEffect(() => {

--- a/src/components/Organization/OrgUsers/OrgUsers.jsx
+++ b/src/components/Organization/OrgUsers/OrgUsers.jsx
@@ -3,6 +3,7 @@ import { makeStyles } from "@mui/styles";
 import React from "react";
 import AddIcon from "@mui/icons-material/Add";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import OrgUsersCard from "../OrgUsersCard/orgUsersCard";
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -67,8 +68,14 @@ function Orgusers({
   dataTestId
 }) {
   const classes = useStyles();
+  const [show, isShow] = React.useState(false);
+  const showAddUserModal = e => {
+    e.preventDefault();
+    isShow(true);
+  };
   return (
     <React.Fragment>
+      {show && <OrgUsersCard />}
       <Paper elevation={0} className={classes.root} data-testid={dataTestId}>
         <Grid container className={classes.gridPadding}>
           <Grid container direction="row">
@@ -96,6 +103,7 @@ function Orgusers({
                 style={{
                   display: AddUser ? "flex" : "none"
                 }}
+                onClick={showAddUserModal}
               >
                 <AddIcon />
                 Add New

--- a/src/components/Organization/OrgUsersCard/addOrgUserModal.jsx
+++ b/src/components/Organization/OrgUsersCard/addOrgUserModal.jsx
@@ -80,9 +80,7 @@ const AddOrgUserModal = ({ currentOrgHandle }) => {
   }, [userProps]);
 
   const onFinish = async () => {
-    const handleExists = await checkUserHandleExists(handle)(
-      firebase
-    );
+    const handleExists = await checkUserHandleExists(handle)(firebase);
 
     if (handle.length < 1) {
       setHandleValidateError(true);
@@ -128,8 +126,8 @@ const AddOrgUserModal = ({ currentOrgHandle }) => {
         id="Search"
         autoComplete="off"
         onChange={(event, value) => {
-          console.log("Value",value)
-          setHandle(value.value)
+          console.log("Value", value);
+          setHandle(value.value);
         }}
         helperText={handleValidateError ? handleValidateErrorMessage : null}
         options={users}

--- a/src/components/Organization/OrgUsersCard/addOrgUserModal.jsx
+++ b/src/components/Organization/OrgUsersCard/addOrgUserModal.jsx
@@ -39,10 +39,16 @@ const AddOrgUserModal = ({ currentOrgHandle }) => {
 
   useEffect(() => {
     setUsers([]);
-    firebase.ref(`cl_user_handle/`).on("value", snapshot => {
-      snapshot.forEach(snap => {
-        setUsers(prev => [...prev, { title: snap.key, value: snap.key }]);
+    const db = firebase.firestore();
+    db.collection("cl_user").onSnapshot(snapshot => {
+      const uniqueHandles = new Set();
+      snapshot.forEach(doc => {
+        const handle = doc.data().handle;
+        const userId = doc.id;
+        uniqueHandles.add({ title: handle, value: userId });
       });
+      const uniqueUsers = Array.from(uniqueHandles);
+      setUsers(uniqueUsers);
     });
   }, [firebase]);
 
@@ -75,8 +81,7 @@ const AddOrgUserModal = ({ currentOrgHandle }) => {
 
   const onFinish = async () => {
     const handleExists = await checkUserHandleExists(handle)(
-      firebase,
-      dispatch
+      firebase
     );
 
     if (handle.length < 1) {
@@ -107,7 +112,7 @@ const AddOrgUserModal = ({ currentOrgHandle }) => {
         org_handle: currentOrgHandle,
         permissions: parseInt(selected.split("_")[1]),
         handle: handle
-      })(firestore, dispatch);
+      })(firestore, firebase, dispatch);
     }
   };
 
@@ -122,7 +127,10 @@ const AddOrgUserModal = ({ currentOrgHandle }) => {
         variant="outlined"
         id="Search"
         autoComplete="off"
-        onChange={e => setHandle(e.target.innerHTML)}
+        onChange={(event, value) => {
+          console.log("Value",value)
+          setHandle(value.value)
+        }}
         helperText={handleValidateError ? handleValidateErrorMessage : null}
         options={users}
         getOptionLabel={option => option.title}
@@ -138,7 +146,6 @@ const AddOrgUserModal = ({ currentOrgHandle }) => {
           />
         )}
       />
-      {console.log(users)}
       <Grid container justify="flex-end">
         <div style={{ padding: "10px" }}>
           <span style={{ paddingRight: "10px" }}>Select user role</span>

--- a/src/components/Organization/ViewOrganization/index.jsx
+++ b/src/components/Organization/ViewOrganization/index.jsx
@@ -124,7 +124,7 @@ const ViewOrganization = () => {
       });
   }, [db, profileData.uid]);
 
-  const [currentOrgData, setCurrentOrgData]=useState(CurrentOrg)
+  const [currentOrgData, setCurrentOrgData] = useState(CurrentOrg);
 
   const handleOrgSubscription = async () => {
     if (!currentOrgData.userSubscription)

--- a/src/components/Organization/ViewOrganization/index.jsx
+++ b/src/components/Organization/ViewOrganization/index.jsx
@@ -124,6 +124,8 @@ const ViewOrganization = () => {
       });
   }, [db, profileData.uid]);
 
+  const [currentOrgData, setCurrentOrgData]=useState(CurrentOrg)
+
   const handleOrgSubscription = async () => {
     if (!currentOrgData.userSubscription)
       await subscribeOrg(handle)(firebase, firestore, dispatch);
@@ -138,13 +140,13 @@ const ViewOrganization = () => {
     }) => loading
   );
 
-  const currentOrgData = useSelector(
-    ({
-      org: {
-        data: { data }
-      }
-    }) => data
-  );
+  // const currentOrgData = useSelector(
+  //   ({
+  //     org: {
+  //       data: { data }
+  //     }
+  //   }) => data
+  // );
 
   const organizations = useSelector(
     ({

--- a/src/store/actions/authActions.js
+++ b/src/store/actions/authActions.js
@@ -178,10 +178,12 @@ export const resendVerifyEmail = email => async dispatch => {
  */
 export const checkUserHandleExists = userHandle => async firebase => {
   try {
-    const handle = await firebase
-      .ref(`/cl_user_handle/${userHandle}`)
-      .once("value");
-    return handle.exists();
+    const userSnapshot = await firebase
+      .firestore()
+      .collection("cl_user")
+      .doc(userHandle)
+      .get();
+    return userSnapshot.exists;
   } catch (e) {
     throw e.message;
   }

--- a/src/store/actions/orgActions.js
+++ b/src/store/actions/orgActions.js
@@ -46,22 +46,25 @@ export const getOrgUserData = org_handle => async (firestore, dispatch) => {
 // adds a user to organization's users list with a set of permissions
 export const addOrgUser =
   ({ org_handle, handle, permissions }) =>
-  async (firestore, dispatch) => {
+  async (firestore, firebase, dispatch) => {
     try {
       dispatch({ type: actions.ADD_ORG_USER_START });
-      const userDoc = await firestore
+      const userDoc = await firebase
+        .firestore()
         .collection("cl_user")
-        .where("handle", "==", handle)
+        .doc(handle)
         .get();
-      if (userDoc.docs.length === 1) {
-        const uid = userDoc.docs[0].get("uid");
+
+      if (userDoc.exists) {
+        const userData = userDoc.data();
+        const uid = userData.uid;
         await firestore
           .collection("org_users")
           .doc(`${org_handle}_${uid}`)
           .set({
             uid: uid,
             org_handle: org_handle,
-            permissions: permissions
+            permissions: [permissions]
           });
 
         await getOrgUserData(org_handle)(firestore, dispatch);
@@ -73,7 +76,7 @@ export const addOrgUser =
         });
       }
     } catch (e) {
-      console.log(e);
+      console.error("Error adding org user:", e);
       dispatch({ type: actions.ADD_ORG_USER_FAIL, payload: e.message });
     }
   };

--- a/src/store/actions/tutorialsActions.js
+++ b/src/store/actions/tutorialsActions.js
@@ -230,36 +230,36 @@ export const getCurrentTutorialData =
 
 export const addNewTutorialStep =
   ({ owner, tutorial_id, title, time, id }) =>
-    async (firebase, firestore, dispatch) => {
-      try {
-        dispatch({ type: actions.CREATE_TUTORIAL_STEP_START });
+  async (firebase, firestore, dispatch) => {
+    try {
+      dispatch({ type: actions.CREATE_TUTORIAL_STEP_START });
 
-        await firestore
-          .collection("tutorials")
-          .doc(tutorial_id)
-          .collection("steps")
-          .doc(id)
-          .set({
-            content: `Switch to editor mode to begin <b>${title}</b> step`,
-            id,
-            time,
-            title,
-            visibility: true,
-            deleted: false
-          });
+      await firestore
+        .collection("tutorials")
+        .doc(tutorial_id)
+        .collection("steps")
+        .doc(id)
+        .set({
+          content: `Switch to editor mode to begin <b>${title}</b> step`,
+          id,
+          time,
+          title,
+          visibility: true,
+          deleted: false
+        });
 
-        await getCurrentTutorialData(owner, tutorial_id)(
-          firebase,
-          firestore,
-          dispatch
-        );
+      await getCurrentTutorialData(owner, tutorial_id)(
+        firebase,
+        firestore,
+        dispatch
+      );
 
-        dispatch({ type: actions.CREATE_TUTORIAL_STEP_SUCCESS });
-      } catch (e) {
-        console.log("CREATE_TUTORIAL_STEP_FAIL", e.message);
-        dispatch({ type: actions.CREATE_TUTORIAL_STEP_FAIL, payload: e.message });
-      }
-    };
+      dispatch({ type: actions.CREATE_TUTORIAL_STEP_SUCCESS });
+    } catch (e) {
+      console.log("CREATE_TUTORIAL_STEP_FAIL", e.message);
+      dispatch({ type: actions.CREATE_TUTORIAL_STEP_FAIL, payload: e.message });
+    }
+  };
 
 export const clearCreateTutorials = () => dispatch =>
   dispatch({ type: actions.CLEAR_CREATE_TUTORIALS_STATE });
@@ -305,78 +305,78 @@ export const setCurrentStepContent =
 
 export const hideUnHideStep =
   (owner, tutorial_id, step_id, visibility) =>
-    async (firebase, firestore, dispatch) => {
-      try {
-        /* not being used */
-        // const type = await checkUserOrOrgHandle(owner)(firebase);
-        await firestore
-          .collection("tutorials")
-          .doc(tutorial_id)
-          .collection("steps")
-          .doc(step_id)
-          .update({
-            [`visibility`]: !visibility,
-            updatedAt: firestore.FieldValue.serverTimestamp()
-          });
+  async (firebase, firestore, dispatch) => {
+    try {
+      /* not being used */
+      // const type = await checkUserOrOrgHandle(owner)(firebase);
+      await firestore
+        .collection("tutorials")
+        .doc(tutorial_id)
+        .collection("steps")
+        .doc(step_id)
+        .update({
+          [`visibility`]: !visibility,
+          updatedAt: firestore.FieldValue.serverTimestamp()
+        });
 
-        await getCurrentTutorialData(owner, tutorial_id)(
-          firebase,
-          firestore,
-          dispatch
-        );
-      } catch (e) {
-        console.log(e.message);
-      }
-    };
+      await getCurrentTutorialData(owner, tutorial_id)(
+        firebase,
+        firestore,
+        dispatch
+      );
+    } catch (e) {
+      console.log(e.message);
+    }
+  };
 
 export const publishUnpublishTutorial =
   (owner, tutorial_id, isPublished) =>
-    async (firebase, firestore, dispatch) => {
-      try {
-        await firestore
-          .collection("tutorials")
-          .doc(tutorial_id)
-          .update({
-            ["isPublished"]: !isPublished
-          });
+  async (firebase, firestore, dispatch) => {
+    try {
+      await firestore
+        .collection("tutorials")
+        .doc(tutorial_id)
+        .update({
+          ["isPublished"]: !isPublished
+        });
 
-        getCurrentTutorialData(owner, tutorial_id)(firebase, firestore, dispatch);
-      } catch (e) {
-        console.log(e.message);
-      }
-    };
+      getCurrentTutorialData(owner, tutorial_id)(firebase, firestore, dispatch);
+    } catch (e) {
+      console.log(e.message);
+    }
+  };
 
 export const removeStep =
   (owner, tutorial_id, step_id, current_step_no) =>
-    async (firebase, firestore, dispatch) => {
-      try {
-        await firestore
-          .collection("tutorials")
-          .doc(tutorial_id)
-          .collection("steps")
-          .doc(step_id)
-          .delete()
+  async (firebase, firestore, dispatch) => {
+    try {
+      await firestore
+        .collection("tutorials")
+        .doc(tutorial_id)
+        .collection("steps")
+        .doc(step_id)
+        .delete();
 
-        // const data = await firestore
-        //   .collection("tutorials")
-        //   .doc(tutorial_id)
-        //   .collection("steps")
-        //   .doc(step_id)
-        //   .get();
+      // const data = await firestore
+      //   .collection("tutorials")
+      //   .doc(tutorial_id)
+      //   .collection("steps")
+      //   .doc(step_id)
+      //   .get();
 
-        await setCurrentStepNo(
-          current_step_no > 0 ? current_step_no - 1 : current_step_no
-        )(dispatch);
+      await setCurrentStepNo(
+        current_step_no > 0 ? current_step_no - 1 : current_step_no
+      )(dispatch);
 
-        await getCurrentTutorialData(owner, tutorial_id)(
-          firebase,
-          firestore,
-          dispatch
-        );
-      } catch (e) {
-        console.log(e.message);
-      }
-    };
+      await getCurrentTutorialData(owner, tutorial_id)(
+        firebase,
+        firestore,
+        dispatch
+      );
+    } catch (e) {
+      console.log(e.message);
+    }
+  };
 
 export const setCurrentStep = data => async dispatch =>
   dispatch({ type: actions.SET_EDITOR_DATA, payload: data });
@@ -465,69 +465,69 @@ export const remoteTutorialImages =
 
 export const updateStepTitle =
   (owner, tutorial_id, step_id, step_title) =>
-    async (firebase, firestore, dispatch) => {
-      try {
-        const dbPath = `tutorials/${tutorial_id}/steps`;
-        await firestore
-          .collection(dbPath)
-          .doc(step_id)
-          .update({
-            [`title`]: step_title,
-            updatedAt: firestore.FieldValue.serverTimestamp()
-          });
-
-        await getCurrentTutorialData(owner, tutorial_id)(
-          firebase,
-          firestore,
-          dispatch
-        );
-      } catch (e) {
-        console.log(e);
-      }
-    };
-
-export const updateStepTime =
-  (owner, tutorial_id, step_id, step_time) =>
-    async (firebase, firestore, dispatch) => {
-      try {
-        const dbPath = `tutorials/${tutorial_id}/steps`;
-
-        await firestore
-          .collection(dbPath)
-          .doc(step_id)
-          .update({
-            [`time`]: step_time,
-            updatedAt: firestore.FieldValue.serverTimestamp()
-          });
-
-        await getCurrentTutorialData(owner, tutorial_id)(
-          firebase,
-          firestore,
-          dispatch
-        );
-      } catch (e) {
-        console.log(e.message);
-      }
-    };
-
-export const setTutorialTheme =
-  ({ tutorial_id, owner, bgColor, textColor }) =>
-    async (firebase, firestore, dispatch) => {
-      try {
-        const dbPath = `tutorials`;
-
-        await firestore.collection(dbPath).doc(tutorial_id).update({
-          text_color: textColor,
-          background_color: bgColor,
+  async (firebase, firestore, dispatch) => {
+    try {
+      const dbPath = `tutorials/${tutorial_id}/steps`;
+      await firestore
+        .collection(dbPath)
+        .doc(step_id)
+        .update({
+          [`title`]: step_title,
           updatedAt: firestore.FieldValue.serverTimestamp()
         });
 
-        await getCurrentTutorialData(owner, tutorial_id)(
-          firebase,
-          firestore,
-          dispatch
-        );
-      } catch (e) {
-        console.log(e.message);
-      }
-    };
+      await getCurrentTutorialData(owner, tutorial_id)(
+        firebase,
+        firestore,
+        dispatch
+      );
+    } catch (e) {
+      console.log(e);
+    }
+  };
+
+export const updateStepTime =
+  (owner, tutorial_id, step_id, step_time) =>
+  async (firebase, firestore, dispatch) => {
+    try {
+      const dbPath = `tutorials/${tutorial_id}/steps`;
+
+      await firestore
+        .collection(dbPath)
+        .doc(step_id)
+        .update({
+          [`time`]: step_time,
+          updatedAt: firestore.FieldValue.serverTimestamp()
+        });
+
+      await getCurrentTutorialData(owner, tutorial_id)(
+        firebase,
+        firestore,
+        dispatch
+      );
+    } catch (e) {
+      console.log(e.message);
+    }
+  };
+
+export const setTutorialTheme =
+  ({ tutorial_id, owner, bgColor, textColor }) =>
+  async (firebase, firestore, dispatch) => {
+    try {
+      const dbPath = `tutorials`;
+
+      await firestore.collection(dbPath).doc(tutorial_id).update({
+        text_color: textColor,
+        background_color: bgColor,
+        updatedAt: firestore.FieldValue.serverTimestamp()
+      });
+
+      await getCurrentTutorialData(owner, tutorial_id)(
+        firebase,
+        firestore,
+        dispatch
+      );
+    } catch (e) {
+      console.log(e.message);
+    }
+  };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Loaded all the users of current organization using `getOrgUserData` action, then populated the contributors with that data, there is no `desg` field in users id that's why no desgination shown in video.
Will soon add/merge the PR for follow button workings at home as well, then can add the org users, load the data dynamically as well as follow and unfollow that user.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #81 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
A touch of dynamism to our codelabz.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally on my machine.

## Video reference:

https://github.com/c2siorg/Codelabz/assets/123815256/739e10ab-fbe8-488c-89b0-b019651474b1



## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
