### PR TITLE
[ Feat : Loading Dynamic Data in Who To Follow Section in Home Page ]

### DIFF
--- a/src/components/CardTabs/Users/UserElement.jsx
+++ b/src/components/CardTabs/Users/UserElement.jsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import Box from "@mui/material/Box";
 import AddUser from "../../../assets/images/add-user.svg";
 import CheckUser from "../../../assets/images/square-check-regular.svg";
+import OrgUser from "../../../assets/images/org-user.svg";
 
 const UserElement = ({ user, index, useStyles }) => {
   const classes = useStyles();
@@ -26,7 +27,7 @@ const UserElement = ({ user, index, useStyles }) => {
         }}
       >
         <img
-          src={user.img[0]}
+          src={user?.img[0] || OrgUser}
           className={classes.userImg}
           data-testId={index == 0 ? "UsersCardImg" : ""}
         />
@@ -35,13 +36,13 @@ const UserElement = ({ user, index, useStyles }) => {
             sx={{ fontWeight: 600, fontSize: "1rem" }}
             data-testId={index == 0 ? "UserName" : ""}
           >
-            {user.name}
+            {user?.name}
           </Box>
           <Box
             sx={{ fontWeight: 400, fontSize: "0.8rem" }}
             data-testId={index == 0 ? "UserDesg" : ""}
           >
-            {user.desg}
+            {user?.desg}
           </Box>
         </Box>
       </Box>

--- a/src/components/HomePage/index.jsx
+++ b/src/components/HomePage/index.jsx
@@ -37,6 +37,7 @@ import {
   getTutorialFeedData,
   getTutorialFeedIdArray
 } from "../../store/actions/tutorialPageActions";
+import { getAllOrgOwners } from "../../store/actions/orgActions";
 
 function HomePage({ background = "white", textColor = "black" }) {
   const classes = useStyles();
@@ -110,32 +111,42 @@ function HomePage({ background = "white", textColor = "black" }) {
     "React"
   ]);
 
-  const [usersToFollow, setUsersToFollow] = useState([
-    {
-      name: "Janvi Thakkar",
-      img: [OrgUser],
-      desg: "Software Engineer",
-      onClick: {}
-    },
-    {
-      name: "Janvi Thakkar",
-      img: [OrgUser],
-      desg: "Software Engineer",
-      onClick: {}
-    },
-    {
-      name: "Janvi Thakkar",
-      img: [OrgUser],
-      desg: "Software Engineer",
-      onClick: {}
-    },
-    {
-      name: "Janvi Thakkar",
-      img: [OrgUser],
-      desg: "Software Engineer",
-      onClick: {}
-    }
-  ]);
+  // const [usersToFollow, setUsersToFollow] = useState([
+  //   {
+  //     name: "Janvi Thakkar",
+  //     img: [OrgUser],
+  //     desg: "Software Engineer",
+  //     onClick: {}
+  //   },
+  //   {
+  //     name: "Janvi Thakkar",
+  //     img: [OrgUser],
+  //     desg: "Software Engineer",
+  //     onClick: {}
+  //   },
+  //   {
+  //     name: "Janvi Thakkar",
+  //     img: [OrgUser],
+  //     desg: "Software Engineer",
+  //     onClick: {}
+  //   },
+  //   {
+  //     name: "Janvi Thakkar",
+  //     img: [OrgUser],
+  //     desg: "Software Engineer",
+  //     onClick: {}
+  //   }
+  // ]);
+
+  const [usersToFollow, setUsersToFollow] = useState([]);
+  useEffect(() => {
+    const fetchData = async () => {
+      const data = await getAllOrgOwners()(firestore, dispatch);
+      console.log("Data", data);
+      setUsersToFollow(data);
+    };
+    fetchData();
+  }, []);
 
   const [contributors, setContributors] = useState([
     {

--- a/src/store/actions/orgActions.js
+++ b/src/store/actions/orgActions.js
@@ -425,3 +425,27 @@ export const deleteOrganization =
       console.log(e);
     }
   };
+
+export const getAllOrgOwners = () => async (firestore) => {
+  try {
+    const orgUsersSnap = await firestore.collection("org_users").get();
+    const allUserIds = orgUsersSnap.docs.map(doc => doc.id.split("_")[1]);
+    const allUsersDataPromises = allUserIds.map(async userId => {
+      const userDocRef = firestore.collection("cl_user").doc(userId);
+      const userDoc = await userDocRef.get();
+      if (userDoc.exists) {
+        return {
+          uid: userId,
+          name: userDoc.get("displayName"),
+          handle: userDoc.get("handle"),
+          img: userDoc.get("photoURL"),
+        };
+      }
+    });
+
+    const allUsersData = await Promise.all(allUsersDataPromises);
+    return allUsersData;
+  } catch (e) {
+    console.log(e);
+  }
+};

--- a/src/store/actions/orgActions.js
+++ b/src/store/actions/orgActions.js
@@ -426,7 +426,7 @@ export const deleteOrganization =
     }
   };
 
-export const getAllOrgOwners = () => async (firestore) => {
+export const getAllOrgOwners = () => async firestore => {
   try {
     const orgUsersSnap = await firestore.collection("org_users").get();
     const allUserIds = orgUsersSnap.docs.map(doc => doc.id.split("_")[1]);
@@ -438,7 +438,7 @@ export const getAllOrgOwners = () => async (firestore) => {
           uid: userId,
           name: userDoc.get("displayName"),
           handle: userDoc.get("handle"),
-          img: userDoc.get("photoURL"),
+          img: userDoc.get("photoURL")
         };
       }
     });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Created a new action called `getAllOrgOwners` and loading all the owners of the orgs. in the "Who to Follow" section.
And one can find orgs. owners in `org_users` collection where each doc id following this pattern orgname_userId so I have extracted the userId and return an array with that data.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #82 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
To add a touch of dynamism to our codelabz.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally on my machine.

## Video reference:
Here, all the owners of the orgs. is loaded and when I logged in through `Rohit First Id` account then it's not shown under "Who To Follow" section as this user is not an owner of any organization or haven't created any organization. And the owners are present under `org_users` collection only.
That's what I am trying to show.


https://github.com/c2siorg/Codelabz/assets/123815256/f2305487-1d1d-44a0-8514-1e300e9dc94b



## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
