### PR TITLE
Click to quickly navigate to author's profile page

### DIFF
--- a/src/components/TutorialPage/components/UserDetails.jsx
+++ b/src/components/TutorialPage/components/UserDetails.jsx
@@ -7,6 +7,7 @@ import { useFirebase, useFirestore } from "react-redux-firebase";
 import { getUserProfileData } from "../../../store/actions";
 import { isUserFollower } from "../../../store/actions/profileActions";
 import { addUserFollower } from "../../../store/actions";
+import { Link } from "react-router-dom";
 
 const useStyles = makeStyles(() => ({
   container: {
@@ -41,6 +42,9 @@ const User = ({ id, timestamp, size }) => {
       }
     }) => data
   );
+
+  console.log("user", user);
+  console.log("profileData", profileData);  
 
   useEffect(() => {
     const checkIsFollowed = async () => {
@@ -78,20 +82,23 @@ const User = ({ id, timestamp, size }) => {
         xs={6}
       >
         <Grid sx={{ height: "100%", width: "auto" }} item>
-          <Avatar
-            sx={{
-              height: size == "sm" ? "24px" : "40px",
-              width: size == "sm" ? "24px" : "40px"
-            }}
-          >
-            {user?.photoURL && user?.photoURL.length > 0 ? (
-              <img src={user?.photoURL} />
-            ) : (
-              user?.displayName[0]
-            )}
-          </Avatar>
+          <Link to={`/profile/${user.uid}`}>
+            <Avatar
+              sx={{
+                height: size == "sm" ? "24px" : "40px",
+                width: size == "sm" ? "24px" : "40px"
+              }}
+            >
+              {user?.photoURL && user?.photoURL.length > 0 ? (
+                <img src={user?.photoURL} />
+              ) : (
+                user?.displayName[0]
+              )}
+            </Avatar>
+          </Link>
         </Grid>
         <Grid item sx={{ width: "fit-content" }}>
+          <Link to={`/profile/${user.uid}`}>
           <Typography
             sx={{
               fontSize: size == "sm" ? "14px" : "16px"
@@ -101,6 +108,7 @@ const User = ({ id, timestamp, size }) => {
               {user?.displayName}
             </span>
           </Typography>
+          </Link>
           <Typography
             sx={{
               fontSize: size == "sm" ? "10px" : "12px",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added a link to quickly navigate to author's profile page. However the application is not integrated for /profile/user-id. That is one user can not view other user's profile page. So, navigating to a broken link.
Will soon raise a issue regarding this aswell.

## Related Issue

Fixes #160 

## Motivation and Context

One would want to view more of his favourite author's content, so he can quickly go his profile page and view more of his tutorials.

## How Has This Been Tested?

Tested locally on my machine

## Screenshots or GIF (In case of UI changes):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
