### PR TITLE
BUG: "Select Tags" render all Inputs in Capital-case

### DIFF
--- a/src/components/Organization/pages/General.jsx
+++ b/src/components/Organization/pages/General.jsx
@@ -93,7 +93,8 @@ const useStyles = makeStyles(theme => ({
     border: 0,
     direction: "column",
     backgroundColor: theme.palette.grey[200],
-    padding: `${theme.spacing(0.5)}px ${theme.spacing(2)}px`
+    padding: `${theme.spacing(0.5)}px ${theme.spacing(2)}px`,
+    textTransform: "none"
   },
   ProfilePhotoImage: {
     width: theme.spacing(12),


### PR DESCRIPTION
## Purpose of This PR
Fixed the Issue: #230 

## Description

This PR fixes the issue where the Select Tags section was rendering all text in uppercase. The change ensures that text is displayed as originally entered, without being forcefully converted to uppercase.

## Related Issue

Closes #230 

## How Has This Been Tested?

Manually tested the Select Tags component in different scenarios.
Verified that text inside Select Tags now displays with the correct casing.

## Screenshots For Reference:

If Input:
![input-of-select-tags](https://github.com/user-attachments/assets/23c11b26-36b3-4a33-a86a-3f203010f961)

Output Before:
![output-before](https://github.com/user-attachments/assets/ec6cfe60-fe9c-464c-9e4c-f69268c6e946)

Output After correction:
![output-after](https://github.com/user-attachments/assets/6215b8b6-6ddb-4d43-a198-f9843231588e)

Part where code is changed: (highlighted in light-blue)
![added-change-select-tags](https://github.com/user-attachments/assets/45f6e0f6-75f9-4d27-9ddc-3e43fa275d4c)



## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the code style of this project.
