### PR TITLE
Refined Password Window Padding To Great Extent

### DIFF
--- a/src/components/Forms/UserPassword/index.jsx
+++ b/src/components/Forms/UserPassword/index.jsx
@@ -1,66 +1,185 @@
 import React from "react";
-import useStyles from "./styles";
 import { Box, Card, Typography, Button, Switch } from "@mui/material";
 import { Input } from "../../ui-helpers/Inputs/SecondaryInput";
+import useStyles from "./styles";
 
 const UserPassword = () => {
   const classes = useStyles();
 
   return (
-    <Card className={classes.card} data-testId="passwordPage">
+    <Card
+      className={classes.card}
+      data-testId="passwordPage"
+      sx={{
+        p: 3,
+        borderRadius: 3,
+        boxShadow: "0px 4px 20px rgba(0,0,0,0.1)",
+        maxWidth: 500,
+        mx: "auto",
+        background: "linear-gradient(135deg, #ffffff, #f8f9fa)"
+      }}
+    >
       <Box
         component="form"
         noValidate
         sx={{
           display: "flex",
-          flexDirection: "column"
+          flexDirection: "column",
+          gap: 2
         }}
       >
-        <Box style={{ marginBottom: "5px" }}>
-          <Typography className={classes.text}>Old password</Typography>
+        <Box>
+          <Typography
+            className={classes.text}
+            variant="body1"
+            gutterBottom
+          >
+            Old password
+          </Typography>
           <Input
             type="password"
+            placeholder="Enter old password"
             className={classes.input}
             data-testId="oldPassword"
+            sx={{
+              height: "36px !important",
+              padding: "0px 0px !important",
+              backgroundColor: "#f5f3f4 !important",
+              color: "#000000 !important",
+              border: "1px solid #555 !important",
+              borderRadius: "4px !important",
+              "& .MuiInputBase-input::placeholder": {
+                color: "#000000 !important",
+                fontSize: "0.875rem !important"
+              }
+            }}
           />
         </Box>
-        <Box style={{ margin: "5px 0" }}>
-          <Typography className={classes.text}>New password</Typography>
+
+        <Box>
+          <Typography
+            className={classes.text}
+            variant="body1"
+            gutterBottom
+          >
+            New password
+          </Typography>
           <Input
             type="password"
+            placeholder="Enter your new password"
             className={classes.input}
             data-testId="newPassword"
+            sx={{
+              height: "36px !important",
+              padding: "0px 0px !important",
+              backgroundColor: "#f5f3f4 !important",
+              color: "#000000 !important",
+              border: "1px solid #555 !important",
+              borderRadius: "4px !important",
+              "& .MuiInputBase-input::placeholder": {
+                color: "#000000 !important",
+                fontSize: "0.875rem !important"
+              }
+            }}
           />
         </Box>
-        <Box style={{ margin: "5px 0" }}>
-          <Typography className={classes.text}>Confirm new password</Typography>
+
+        <Box>
+          <Typography
+            className={classes.text}
+            variant="body1"
+            gutterBottom
+          >
+            Confirm new password
+          </Typography>
           <Input
             type="password"
+            placeholder="Confirm new password"
             className={classes.input}
             data-testId="confirmPassword"
+            sx={{
+              height: "36px !important",
+              padding: "0px 0px !important",
+              backgroundColor: "#f5f3f4 !important",
+              color: "#000000 !important",
+              border: "1px solid #555 !important",
+              borderRadius: "4px !important",
+              "& .MuiInputBase-input::placeholder": {
+                color: "#000000 !important",
+                fontSize: "0.875rem !important"
+              }
+            }}
           />
         </Box>
-        <Button className={classes.button} data-testId="updatePassword">
+
+        <Button
+          className={classes.button}
+          data-testId="updatePassword"
+          variant="contained"
+          sx={{
+            backgroundColor: "#0073E6 !important",
+            color: "#ffffff !important",
+            py: 1.5,
+            textTransform: "none",
+            fontWeight: "bold",
+            borderRadius: 2,
+            "&:hover": {
+              backgroundColor: "#004A70 !important",
+              color: "#ffffff !important"
+            }
+          }}
+        >
           Update Password
         </Button>
-        <Box className={classes.row}>
-          <Typography className={classes.text} data-testId="logout">
+
+        <Box
+          sx={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            pt: 2,
+            borderTop: "1px solid #e0e0e0"
+          }}
+        >
+          <Typography
+            className={classes.text}
+            data-testId="logout"
+            variant="body2"
+          >
             Logout
           </Typography>
           <Typography
             className={classes.text}
-            style={{ marginRight: 40, color: "#0075AD" }}
             data-testId="logoutOfOtherBrowsers"
+            variant="body2"
+            sx={{ color: "#0075AD", cursor: "pointer" }}
           >
             Logout of all other browsers
           </Typography>
         </Box>
-        <Box className={classes.row}>
-          <Typography className={classes.text} data-testId="loginSecurity">
+
+        <Box
+          sx={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            pt: 2,
+            borderTop: "1px solid #e0e0e0"
+          }}
+        >
+          <Typography
+            className={classes.text}
+            data-testId="loginSecurity"
+            variant="body2"
+          >
             Login security
           </Typography>
-          <Box style={{ display: "flex", alignItems: "center" }}>
-            <Typography className={classes.text}>
+          <Box sx={{ display: "flex", alignItems: "center" }}>
+            <Typography
+              className={classes.text}
+              variant="body2"
+              sx={{ mr: 1 }}
+            >
               Require email verification
             </Typography>
             <Switch color="primary" data-testId="emailVerification" />


### PR DESCRIPTION
## Purpose Of This PR
Described clearly in Issue : #243 

## Description
This **PR** updates the password management **UI** by improving **padding, alignment, and styling** for a cleaner look.

## Related Issue
Closes #243 

## Motivation and Context
Just want to Improve the **user experience**.

## How Has This Been Tested?
Tested **locally** on my **machine** on different **web-browsers**.

## Screenshots or GIF (In case of UI changes):

**Before:**
![password-window-before](https://github.com/user-attachments/assets/ca51f878-1b4d-49bd-82df-659cde0de9ea)

**After:**
![password-window-now](https://github.com/user-attachments/assets/d8e31732-586c-4c73-8c7c-d83a33a97e80)

**Footage(for-reference):**

https://github.com/user-attachments/assets/3a7fc964-15bd-4f97-91c5-da3f00ecbd57



## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
