### PR TITLE
fix: Correct misspelled CSS pseudo-class and invalid MUI Typography variant (#266)

### DIFF
--- a/src/components/Card/CardWithPicture.jsx
+++ b/src/components/Card/CardWithPicture.jsx
@@ -115,7 +115,7 @@ export default function CardWithPicture({ tutorial }) {
           <React.Fragment>
             <Typography
               component="span"
-              variant="h7"
+              variant="subtitle2"
               className={classes.inline}
               color="textPrimary"
               data-testId="UserName"
@@ -127,7 +127,7 @@ export default function CardWithPicture({ tutorial }) {
                 {" for "}
                 <Typography
                   component="span"
-                  variant="h7"
+                  variant="subtitle2"
                   className={classes.inline}
                   color="textPrimary"
                   data-testId="UserOrgName"

--- a/src/components/Card/CardWithoutPicture.jsx
+++ b/src/components/Card/CardWithoutPicture.jsx
@@ -101,7 +101,7 @@ export default function CardWithoutPicture({ tutorial }) {
           <React.Fragment>
             <Typography
               component="span"
-              variant="h7"
+              variant="subtitle2"
               className={classes.inline}
               color="textPrimary"
               data-testId="UserName"
@@ -113,7 +113,7 @@ export default function CardWithoutPicture({ tutorial }) {
                 {" for "}
                 <Typography
                   component="span"
-                  variant="h7"
+                  variant="subtitle2"
                   className={classes.inline}
                   color="textPrimary"
                   data-testId="UserOrgName"

--- a/src/components/HomePage/styles.jsx
+++ b/src/components/HomePage/styles.jsx
@@ -55,7 +55,7 @@ const useStyles = makeStyles(theme => ({
     }
   },
   navigation: {
-    "&:selcted": {
+    "&:selected": {
       border: "2px solid black"
     }
   },


### PR DESCRIPTION
## Fixes #266

### Changes
- **`src/components/HomePage/styles.jsx`** (Line 58): Fixed misspelled CSS pseudo-class `"&:selcted"` → `"&:selected"`
- **`src/components/Card/CardWithPicture.jsx`** (Lines 118, 130): Fixed invalid MUI Typography `variant="h7"` → `variant="subtitle2"`
- **`src/components/Card/CardWithoutPicture.jsx`** (Lines 104, 116): Fixed invalid MUI Typography `variant="h7"` → `variant="subtitle2"`

### Why
1. `"&:selcted"` is a typo — the CSS rule never matches, so the navigation selected-state border never renders
2. MUI Typography only supports `h1`–`h6`. `"h7"` silently falls back to default `body1`, causing author/org names on tutorial cards to lose their intended styling