### PR TITLE
fix(docker): update to Node 18 and JDK 21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,15 @@
-FROM node:14
+FROM node:18
 
 # Set the working directory in the container
 WORKDIR /app
 
-RUN apt update -y && apt install -y openjdk-11-jdk bash
+# Install JDK 21 (required by firebase-tools for emulators)
+RUN apt update -y && apt install -y wget apt-transport-https gnupg bash && \
+    wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | apt-key add - && \
+    echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print $2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list && \
+    apt update -y && apt install -y temurin-21-jdk
 
-RUN npm install -g firebase-tools@11
+RUN npm install -g firebase-tools
 
 # Pre-download emulators
 RUN firebase setup:emulators:firestore && \
@@ -19,13 +23,13 @@ COPY package*.json ./
 COPY ./functions/package*.json ./functions/
 
 # Install the project dependencies
-RUN npm install
-RUN cd functions && npm install && cd ..
+RUN npm install --legacy-peer-deps
+RUN cd functions && npm install --legacy-peer-deps && cd ..
 
 # Copy the entire project directory to the container
 COPY . .
 
-# Expose the desired port for the Node.js server
+# Expose the desired ports
 EXPOSE 5173
 EXPOSE 4000
 EXPOSE 5000
@@ -35,9 +39,10 @@ EXPOSE 9000
 EXPOSE 8085
 EXPOSE 9199
 EXPOSE 4400
+EXPOSE 9099
 
 RUN mkdir -p scripts
-RUN echo '#!/bin/sh \nfirebase emulators:start --import=testdata --project demo-sampark &\nsleep 10\nnpm run dev --host &\nwait' > ./scripts/entrypoint.sh 
+RUN printf '#!/bin/sh\nfirebase emulators:start --import=testdata --project codelabz-local-test &\nsleep 15\nnpm run dev -- --host &\nwait\n' > ./scripts/entrypoint.sh
 RUN chmod +x ./scripts/entrypoint.sh
 
 CMD ["./scripts/entrypoint.sh"]


### PR DESCRIPTION
## Description

This PR fixes the local Docker development environment which was failing to build.
The `Dockerfile` has been updated to use modern constraints:

1. Updated base image from `node:14` to `node:18` (Node 14 is EOL and incompatible with Vite React SWC).
2. Replaced `openjdk-11-jdk` with Temurin JDK 21 (current `firebase-tools` requires Java 21+ for emulators).
3. Unpinned `firebase-tools@11` to allow installing the latest version.
4. Added `--legacy-peer-deps` to npm install commands to resolve known upstream React 18 / `@mui/styles` peer dependency conflicts.
5. Fixed the entrypoint script to pass `--host` to the Vite dev server so it binds correctly in Docker.

## Related Issue

Fixes #271

## Motivation and Context

Running `docker compose up --build` previously failed during the `npm install` phase due to `ERESOLVE` peer dependency errors. Even if bypassed, the Firebase emulators would immediately crash upon container startup because they require Java 21+, but the container only had Java 11 installed. This change restores the `docker-compose` workflow for local development.

## How Has This Been Tested?

- Verified on Manjaro Linux (Docker v29.2.0)
- Ran `docker compose up --build` on a fresh clone.
- Verified that all 25 build steps complete successfully.
- Verified that the container starts up and successfully boots the Firebase Emulators (Firestore, Database, etc.) importing the `testdata/` payloads.
- Verified the Vite dev server boots and is accessible at `http://localhost:5173`.

## Screenshots or GIF (In case of UI changes):

N/A (Dev environment fix)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
