### PR TITLE
fix: remove unused dispatch params in action creators

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -17,5 +17,6 @@ module.exports = {
     react: {
       version: "detect"
     }
-  }
+  },
+  ignorePatterns: ["src/dataconnect-generated/"]
 };

--- a/src/store/actions/orgActions.js
+++ b/src/store/actions/orgActions.js
@@ -427,7 +427,7 @@ export const deleteOrganization =
     }
   };
 
-  export const getAllOrganizations = () => async (firebase, firestore, dispatch) => {
+  export const getAllOrganizations = () => async (firebase, firestore) => {
     try {
       const orgDocs = await firestore
         .collection("cl_org_general")

--- a/src/store/actions/tutorialPageActions.js
+++ b/src/store/actions/tutorialPageActions.js
@@ -277,7 +277,7 @@ export const getAllTags = () => async (firebase, firestore) => {
 };
 
 
-export const getFilteredTutorials = (selectedTags = []) => async (firebase, firestore, dispatch) => {
+export const getFilteredTutorials = (selectedTags = []) => async (firebase, firestore) => {
   try {
     const tutorialsRef = firestore.collection("tutorials");
     let query = tutorialsRef;


### PR DESCRIPTION
Summary
- Removed unused dispatch parameter from getAllOrganizations in src/store/actions/orgActions.js:430
- Removed unused dispatch parameter from getFilteredTutorials in src/store/actions/tutorialPageActions.js:280
- Added ignore pattern for auto-generated dataconnect-generated/ files in .eslintrc.cjs
Changes
These fixes resolve ESLint errors (no-unused-vars) in the codebase. The dispatch parameter was declared but never used in both action creators.