### PR TITLE
fix(docker): use node:14-bullseye to resolve apt install failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14
+FROM node:14-bullseye
 
 # Set the working directory in the container
 WORKDIR /app


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Docker build was failing at:

RUN apt update -y && apt install -y openjdk-11-jdk bash

Error:
exit code: 100

## Related Issue

Closes #286 

## Motivation and Context

The base image `node:14` pulls a moving Debian tag.
Since Node 14 is EOL, repository metadata may no longer resolve properly,
causing `apt update` to fail with exit code 100.

Switching to `node:14-bullseye` ensures a stable Debian release
and fixes the Docker build failure without affecting runtime behavior.

## How Has This Been Tested?

- Rebuilt the Docker image using:
  docker compose build --no-cache

- Verified that apt update and package installation complete successfully.
- Confirmed that the container starts and runs as expected.

## Screenshots or GIF (In case of UI changes):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
