### PR TITLE
fix: Update Dockerfile to Node 18, OpenJDK 17, and legacy peer deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM node:14
+FROM node:18
 
 # Set the working directory in the container
 WORKDIR /app
 
-RUN apt update -y && apt install -y openjdk-11-jdk bash
+RUN apt update -y && apt install -y openjdk-17-jdk bash
 
 RUN npm install -g firebase-tools@11
 
@@ -19,8 +19,8 @@ COPY package*.json ./
 COPY ./functions/package*.json ./functions/
 
 # Install the project dependencies
-RUN npm install
-RUN cd functions && npm install && cd ..
+RUN npm install --legacy-peer-deps
+RUN cd functions && npm install --legacy-peer-deps && cd ..
 
 # Copy the entire project directory to the container
 COPY . .


### PR DESCRIPTION

## Description

The Docker build is completely broken because the Dockerfile uses node:14, which is based on Debian Buster. Buster is end-of-life and Debian has taken down its package repos, so apt update just 404s.

I've updated 3 lines in the Dockerfile to fix this:

node:14 → node:18 — active base image with working repos
openjdk-11-jdk → openjdk-17-jdk — JDK 11 isn't available in Bookworm
Added --legacy-peer-deps to npm install — npm 9+ (ships with Node 18) is strict about peer deps and some packages like @mui/styles still expect React 17

## Related Issue

#286 issue addresses partially, #301 

## Motivation and Context

You literally can't build or run the app via Docker right now. Every docker compose up fails immediately. This gets it working again with minimal changes — no app code touched, just the Dockerfile.

## How Has This Been Tested?
Ran docker compose build --no-cache — builds successfully (all 13 steps pass)
Ran docker compose up — app starts, Vite dev server runs on port 5173, all Firebase emulators come up and are ready

## Screenshots or GIF (In case of UI changes):

<img width="1915" height="1000" alt="localworking" src="https://github.com/user-attachments/assets/dd68a597-ad02-4e87-9fe3-c3462f81d00d" />

<img width="1548" height="634" alt="working-docker-terminal" src="https://github.com/user-attachments/assets/94b2ef70-274e-496d-9d87-8b0b2219f0ad" />


## Types of changes


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:


- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
