### PR TITLE
fix: create org_users entry when creating an organization

### DIFF
--- a/src/store/actions/profileActions.js
+++ b/src/store/actions/profileActions.js
@@ -86,6 +86,15 @@ export const createOrganization =
         }
       );
 
+      await firestore
+        .collection("org_users")
+        .doc(`${org_handle}_${userData.uid}`)
+        .set({
+          uid: userData.uid,
+          org_handle: org_handle,
+          permissions: [3]
+        });
+
       const timeOutID = setTimeout(() => {
         firestore
           .collection("cl_user")


### PR DESCRIPTION
## Description

Fixes a bug where `createOrganization` created the organization document but did not create the corresponding `org_users` permission entry. Because the system determines organization access through `org_users`, the creator never received admin permissions for the newly created organization, causing it to not appear in the dashboard after creation.

This patch adds the missing `org_users` document write (`org_handle_uid`) with admin permissions `[3]`, mirroring the logic already used in `setUpInitialData`.

---

## Related Issue

Fixes the issue where organizations created from the dashboard become inaccessible due to the missing `org_users` entry.

---

## Motivation and Context

Without this permission entry, `getAllOrgsOfCurrentUser()` cannot detect the newly created organization since it queries `org_users` by `uid`. As a result, organizations created via the sidebar become effectively orphaned and inaccessible to their creator.

---

## How Has This Been Tested?

- Logged in as an existing user
- Created a new organization from the sidebar
- Verified that:
  - The org document is created in `cl_org_general`
  - The user document is updated in `cl_user`
  - The permission entry is created in `org_users`
- Confirmed the organization appears in the dashboard after reload and is accessible.

---

## Screenshots or GIF (In case of UI changes):

N/A

---

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

---

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.