### PR TITLE
Replace Twitter icon with X icon in SmButtons component

### DIFF
--- a/src/components/AuthPage/smButton/smButtons.jsx
+++ b/src/components/AuthPage/smButton/smButtons.jsx
@@ -4,7 +4,7 @@ import { useDispatch } from "react-redux";
 import { useFirebase } from "react-redux-firebase";
 import GoogleImg from "../../../assets/orgs/google.png";
 import GitHubIcon from "@mui/icons-material/GitHub";
-import TwitterIcon from "@mui/icons-material/Twitter";
+import XIcon from "@mui/icons-material/X";
 import FacebookIcon from "@mui/icons-material/Facebook";
 import { signInWithGoogle, signInWithProviderID } from "../../../store/actions";
 import useStyles from "./styles";
@@ -50,9 +50,9 @@ const SmButtons = () => {
           onClick={() => signInWithProviderID("twitter")(firebase, dispatch)}
           className={classes.button}
         >
-          <TwitterIcon className={classes.tw}>
-            <span className="sm-text">Twitter</span>
-          </TwitterIcon>
+          <XIcon className={classes.tw}>
+            <span className="sm-text">X</span>
+          </XIcon>
         </IconButton>
       </Grid>
       <Grid item>


### PR DESCRIPTION


## Description

This PR updates the **Twitter logo to the X logo** in the social login section of the signup page.
Twitter has been rebranded to **X**, so the UI should reflect the latest branding to avoid confusion and keep the interface up to date.

---

## Related Issue

Fixes #304 
---

## Motivation and Context

Twitter has officially rebranded to **X**, but the current UI still displays the **old Twitter logo**.
Updating the logo ensures the application follows the **latest branding guidelines** and provides a more accurate user experience.

---

## How Has This Been Tested?

Steps used to test the change:

1. Ran the project locally.
2. Navigated to the **Sign Up / Create Account page**.
3. Scrolled to the **social login section**.
4. Verified that the **Twitter icon is replaced with the X logo**.
5. Ensured the layout and styling remain unchanged.

Testing Environment:

* OS: Ubuntu / Linux
* Browser: Google Chrome
* Version: 141.0.0.0

---

## Screenshots or GIF (In case of UI changes):

**Before:** Twitter logo displayed in the social login section.
<img width="1141" height="448" alt="Screenshot From 2026-03-05 10-41-01" src="https://github.com/user-attachments/assets/696c7664-0033-432c-8af6-8acdb9a9552d" />


**After:** Updated to the **X logo**.

<img width="1141" height="448" alt="Screenshot From 2026-03-05 10-52-27" src="https://github.com/user-attachments/assets/57f6bfee-4dd5-4ea8-b01d-e96f76305550" />


---

## Types of changes

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

---

## Checklist:

* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.
