### PR TITLE
fix: correct email validation trim and grammar in signup formfix: correct email validation trim and grammar in signup form

### DIFF
--- a/src/components/AuthPage/SignUp/signupForm.jsx
+++ b/src/components/AuthPage/SignUp/signupForm.jsx
@@ -91,9 +91,9 @@ const SignupForm = () => {
       setEmailValidateErrorMessage("Please Enter your Email!");
       return false;
     }
-    if (!validator.isEmail(email)) {
+    if (!validator.isEmail(email.trim())) {
       setEmailValidateError(true);
-      setEmailValidateErrorMessage("Please enter an valid email!");
+      setEmailValidateErrorMessage("Please enter a valid email!");
       return false;
     }
     return true;


### PR DESCRIPTION
## Problem
Email validation in the signup form was rejecting valid emails due to 
missing .trim() on the input, causing false "invalid email" errors when 
users had accidental whitespace. Also fixed a grammar error in the error 
message ("an valid" → "a valid").

## Changes
- Added .trim() to email validation to handle whitespace
- Fixed grammar: "Please enter an valid email!" → "Please enter a valid email!"

## Testing
- Tested signup with valid emails - now works correctly
- Tested with whitespace around email - now handled properly