### PR TITLE
fix: replace bitwise AND with logical AND in login validation

### DIFF
--- a/src/components/AuthPage/Login/index.jsx
+++ b/src/components/AuthPage/Login/index.jsx
@@ -99,6 +99,11 @@ const Login = ({
   const onSubmit = async e => {
     e.preventDefault();
     setError("");
+    // Clear previous validation errors so only current errors are shown
+    setEmailValidateError(false);
+    setEmailValidateErrorMessage("");
+    setPasswordValidateError(false);
+    setPasswordValidateErrorMessage("");
     if (validateEmail() && validatePassword()) {
       await signIn({ email: email, password: password })(firebase, dispatch);
     }

--- a/src/components/AuthPage/Login/index.jsx
+++ b/src/components/AuthPage/Login/index.jsx
@@ -104,9 +104,18 @@ const Login = ({
     setEmailValidateErrorMessage("");
     setPasswordValidateError(false);
     setPasswordValidateErrorMessage("");
-    if (validateEmail() && validatePassword()) {
-      await signIn({ email: email, password: password })(firebase, dispatch);
+
+    const isEmailValid = validateEmail();
+    if (!isEmailValid) {
+      return;
     }
+
+    const isPasswordValid = validatePassword();
+    if (!isPasswordValid) {
+      return;
+    }
+
+    await signIn({ email: email, password: password })(firebase, dispatch);
   };
 
   const onFocusEmail = () => {

--- a/src/components/AuthPage/Login/index.jsx
+++ b/src/components/AuthPage/Login/index.jsx
@@ -99,7 +99,7 @@ const Login = ({
   const onSubmit = async e => {
     e.preventDefault();
     setError("");
-    if (validateEmail() & validatePassword()) {
+    if (validateEmail() && validatePassword()) {
       await signIn({ email: email, password: password })(firebase, dispatch);
     }
   };


### PR DESCRIPTION
## Description
Replaced the bitwise AND operator (`&`) with the logical AND operator (`&&`) 
in the login form's `onSubmit` validation function.

## Related Issue
Fixes #312

## Motivation and Context
The bitwise `&` operator caused both `validateEmail()` and `validatePassword()` 
to always execute simultaneously, even when the first check failed. This showed 
multiple error messages at once, creating a confusing user experience.

Using `&&` enables short-circuit evaluation — if email validation fails, 
Password validation is skipped, showing only one error at a time.

## How Has This Been Tested?
- Tested on local development environment (`localhost:5173`)
- Entered invalid email with empty password → only email error shows ✅
- Fixed email, left password empty → only password error shows ✅
- Both valid → login proceeds normally ✅

## Screenshots or GIF

After fix: Only email error shows when email is invalid 
(password validation is skipped due to short-circuit evaluation)
<img width="1470" height="727" alt="Screenshot 2026-03-12 at 5 03 24 PM" src="https://github.com/user-attachments/assets/4f8c1838-30ec-488d-b660-fd62dbd2c5e3" />


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
