### PR TITLE
Fix infinite useEffect re-rendering in AuthIsLoaded

### DIFF
--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useRef } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import {
   isEmpty,
@@ -39,17 +39,30 @@ const AuthIsLoaded = ({ children }) => {
   const firebase = useFirebase();
   const firestore = useFirestore();
   const dispatch = useDispatch();
+  const hasFetchedRef = useRef(false);
 
+  const auth = useSelector(({ firebase: { auth } }) => auth);
   const profile = useSelector(({ firebase: { profile } }) => profile);
   const data = useSelector(({ profile: { data } }) => data);
   const general = useSelector(({ org: { general } }) => general);
 
   useEffect(() => {
-    if (isLoaded(profile) && isLoaded(data) && isLoaded(general)) {
-      return; // Avoid fetching if data is already loaded
-    }
+    // skip if we already fetched or auth hasn't loaded yet
+    if (hasFetchedRef.current || !isLoaded(auth)) return;
+
+    // no need to fetch profile data for unauthenticated users
+    if (isEmpty(auth)) return;
+
+    hasFetchedRef.current = true;
     getProfileData()(firebase, firestore, dispatch);
-  }, [profile, firestore, firebase, dispatch]);
+  }, [auth, firebase, firestore, dispatch]);
+
+  // reset the flag if user logs out so we re-fetch on next login
+  useEffect(() => {
+    if (isLoaded(auth) && isEmpty(auth)) {
+      hasFetchedRef.current = false;
+    }
+  }, [auth]);
 
   //case for not logged in user
   if (


### PR DESCRIPTION
## Description

Fixed the infinite re-rendering loop in `AuthIsLoaded` component (`src/routes.jsx`). The `useEffect` was running endlessly because `profile` was included in the dependency array - since its an object from Redux, it gets a new reference every time the store updates, which re-triggers the effect, which dispatches more actions, which updates the store again.. you get the idea.

## Related Issue

Fixes #315

## Motivation and Context

The develop branch was basically unusable because of this. Every page load would trigger hundreds of re-renders per second, maxing out CPU and making the app unresponsive.

The root cause: `getProfileData()` dispatches `GET_PROFILE_DATA_START` which updates the Redux store. This gives the `profile` selector a new object reference, which satisfies React's dependency check and re-runs the effect. Even though there was an early return guard checking `isLoaded()`, it didn't help during the loading phase when data hasn't arrived yet.

## How Has This Been Tested?

- Verified the build completes successfully with `vite build`
- Confirmed the two existing lint warnings (`MainNavbar` unused import and missing prop-types) are pre-existing and not introduced by this change
- Tested the logic flow: authenticated users get profile data fetched once, unauthenticated users skip the fetch entirely, logging out resets the ref so a new login triggers a fresh fetch

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.