### PR TITLE
Fix bitwise operator in login validation

### DIFF
--- a/src/components/AuthPage/Login/index.jsx
+++ b/src/components/AuthPage/Login/index.jsx
@@ -99,7 +99,7 @@ const Login = ({
   const onSubmit = async e => {
     e.preventDefault();
     setError("");
-    if (validateEmail() & validatePassword()) {
+    if (validateEmail() && validatePassword()) {
       await signIn({ email: email, password: password })(firebase, dispatch);
     }
   };


### PR DESCRIPTION
## Problem

The login form's `onSubmit` handler uses a bitwise AND (`&`) instead of a logical AND (`&&`) on line 102 of `src/components/AuthPage/Login/index.jsx`:

```js
if (validateEmail() & validatePassword()) {
```

This means `validatePassword()` always runs even when `validateEmail()` returns false. Both error messages show up at the same time, which is confusing for users.

## Fix

Replaced `&` with `&&` so short-circuit evaluation kicks in. Now if the email is invalid, the password validation is skipped and users see one error at a time.

## Testing

Tested locally by entering an invalid email with an empty password field. Before the fix, both errors appeared. After, only the email error shows until it passes.

Fixes #312