### PR TITLE
fix: upgrade Docker base image from node:14 to node:18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14
+FROM node:18
 
 # Set the working directory in the container
 WORKDIR /app


### PR DESCRIPTION
## Problem

Docker build is broken because `node:14` is based on Debian Buster, which reached end-of-life. The Debian package repositories have been taken down, so `apt-get update` fails with 404 errors during `docker build`.

## Fix

Upgraded the base image in `Dockerfile` from `node:14` to `node:18` (active LTS). The project already uses Vite 5 and React 18, both of which are fully compatible with Node 18.

## Testing

- Verified `docker build` no longer fails at the apt update step
- Confirmed `docker compose up` starts the dev server on port 5173

Fixes #300