### PR TITLE
ui: overhaul tutorial editor layout and navigation responsiveness

### DIFF
--- a/src/components/NavBar/new/MainNavbar/RightMenu.jsx
+++ b/src/components/NavBar/new/MainNavbar/RightMenu.jsx
@@ -22,7 +22,8 @@ import {
   AccordionSummary,
   List,
   ListItem,
-  Typography
+  Typography,
+  Box
 } from "@mui/material";
 import { useTheme } from "@mui/styles";
 import useMediaQuery from "@mui/material/useMediaQuery";
@@ -46,7 +47,7 @@ const useStyles = makeStyles(theme => ({
   }
 }));
 
-const RightMenu = ({ mode, onClick }) => {
+const RightMenu = ({ mode, onClick, nav }) => {
   const theme = useTheme();
   const matches = useMediaQuery(theme.breakpoints.down("sm"));
   const { pathname } = useLocation();
@@ -95,25 +96,9 @@ const RightMenu = ({ mode, onClick }) => {
 
   const allowOrgs = organizations && organizations.length > 0;
 
-  const orgList =
-    allowOrgs > 0
-      ? organizations.map((org, i) => {
-          return (
-            <Menu.Item key={`org:${i}`}>
-              <Link to={`/org/${org.org_handle}`}>
-                <Avatar src={org.org_image} size="small" className="mr-8 ml-0">
-                  {avatarName(org.org_name)}
-                </Avatar>{" "}
-                {org.org_name}
-              </Link>
-            </Menu.Item>
-          );
-        })
-      : null;
-
   const classes = useStyles();
 
-  if (matches) {
+  if (matches && !nav) {
     return (
       <React.Fragment>
         <List>
@@ -232,10 +217,11 @@ const RightMenu = ({ mode, onClick }) => {
   }
 
   return (
-    <Grid
-      container
-      style={{
-        marginRight: "2rem"
+    <Box
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        ml: { xs: 0, sm: 2 }
       }}
     >
       <Avatar
@@ -244,8 +230,6 @@ const RightMenu = ({ mode, onClick }) => {
             profile.photoURL && profile.photoURL.length > 0
               ? "#fffff"
               : "#3AAFA9",
-          marginLeft: "1rem",
-          marginBottom: ".2rem",
           cursor: "pointer"
         }}
         size={mode === "inline" ? "default" : "medium"}
@@ -375,7 +359,7 @@ const RightMenu = ({ mode, onClick }) => {
           </Typography>
         </MenuItem>
       </Menu>
-    </Grid>
+    </Box>
   );
 };
 

--- a/src/components/NavBar/new/MainNavbar/index.jsx
+++ b/src/components/NavBar/new/MainNavbar/index.jsx
@@ -1,4 +1,11 @@
-import { Grid, IconButton, InputBase, Paper, Typography } from "@mui/material";
+import {
+  Box,
+  Grid,
+  IconButton,
+  InputBase,
+  Paper,
+  Typography
+} from "@mui/material";
 import { makeStyles } from "@mui/styles";
 import React, { useState } from "react";
 import Headroom from "react-headroom";
@@ -8,7 +15,6 @@ import RightMenu from "./RightMenu";
 import LeftMenu from "./LeftMenu";
 import { useHistory } from "react-router-dom";
 import MenuIcon from "@mui/icons-material/Menu";
-import CloseIcon from "@mui/icons-material/Close";
 import { useSelector } from "react-redux";
 import SideBar from "../../../SideBar/index";
 import useWindowSize from "../../../../helpers/customHooks/useWindowSize";
@@ -28,7 +34,11 @@ const useStyles = makeStyles(theme => ({
     backgroundColor: theme.palette.grey[50],
     padding: "2px",
     border: "1px solid #ced4da",
-    borderRadius: "0.8rem"
+    borderRadius: "0.8rem",
+    [theme.breakpoints.between("sm", "md")]: {
+      maxWidth: "60%",
+      margin: "0 auto"
+    }
   },
   icon: {
     padding: "2px",
@@ -38,7 +48,8 @@ const useStyles = makeStyles(theme => ({
     width: "auto",
     "& > *": {},
     [theme.breakpoints.down("sm")]: {
-      display: "none"
+      justifyContent: "center",
+      marginTop: theme.spacing(1)
     }
   },
   button: {
@@ -94,38 +105,42 @@ function MainNavbar() {
           direction="row"
           justifyContent="space-between"
           alignItems="center"
+          sx={{ px: { xs: 1, sm: 2 } }}
         >
-          <Grid item container xs={12} md={2} alignItems="center">
-            <Grid
+          <Grid item xs="auto" sx={{ display: "flex", alignItems: "center" }}>
+            <div
+              onClick={() => {
+                history.push("/");
+              }}
+              data-testid="navbarBrand"
               style={{
-                flexGrow: "1"
+                cursor: "pointer",
+                display: "flex",
+                alignItems: "center"
               }}
             >
-              <div
-                onClick={() => {
-                  history.push("/");
-                }}
-                data-testid="navbarBrand"
-              >
-                <BrandName />
-              </div>
-            </Grid>
-            <Grid item className={classes.hamburger}>
-              <IconButton
-                onClick={() => {
-                  toggleSlider();
-                }}
-              >
-                <MenuIcon />
-              </IconButton>
-            </Grid>
+              <BrandName />
+            </div>
           </Grid>
-          <Grid item xs={12} md={5}>
+
+          <Grid
+            item
+            xs
+            sx={{
+              display: { xs: "none", md: "flex" },
+              justifyContent: "center"
+            }}
+          >
             <Paper
               component={"form"}
               className={classes.root}
               elevation={0}
               onSubmit={handleSearch}
+              sx={{
+                maxWidth: "600px",
+                width: "100%",
+                mx: "2rem"
+              }}
             >
               <IconButton
                 type="button"
@@ -145,19 +160,76 @@ function MainNavbar() {
               />
             </Paper>
           </Grid>
+
           <Grid
             item
-            container
-            direction="row"
-            alignItems="center"
-            className={classes.grid}
+            xs="auto"
+            sx={{
+              display: "flex",
+              justifyContent: "flex-end",
+              alignItems: "center",
+              gap: 1
+            }}
           >
-            <Grid item justifyContent="center">
+            <Box
+              sx={{
+                display: { xs: "none", sm: "flex" },
+                alignItems: "center",
+                gap: 1
+              }}
+            >
               <LeftMenu />
-            </Grid>
-            <Grid item>
-              <RightMenu />
-            </Grid>
+            </Box>
+            <RightMenu nav={true} />
+            <Box className={classes.hamburger}>
+              <IconButton
+                onClick={() => {
+                  toggleSlider();
+                }}
+                sx={{ ml: 0.5 }}
+              >
+                <MenuIcon />
+              </IconButton>
+            </Box>
+          </Grid>
+
+          {/* Mobile/Tablet Search Row (Below Logo/Menu) */}
+          <Grid
+            item
+            xs={12}
+            sx={{ display: { xs: "flex", md: "none" }, mt: 2, pb: 1 }}
+          >
+            <Paper
+              component={"form"}
+              className={classes.root}
+              elevation={0}
+              onSubmit={handleSearch}
+              sx={{
+                width: "100%",
+                borderRadius: "2rem",
+                display: "flex",
+                alignItems: "center",
+                px: 1
+              }}
+            >
+              <IconButton
+                type="button"
+                aria-label="search"
+                disableRipple
+                className={classes.icon}
+                data-testid="navbarSearch"
+                onClick={handleSearch}
+              >
+                <SearchIcon />
+              </IconButton>
+              <InputBase
+                className={classes.input}
+                value={searchQuery}
+                placeholder="Search tutorials..."
+                onChange={handleSearchChange}
+                sx={{ width: "100%", ml: 1 }}
+              />
+            </Paper>
           </Grid>
         </Grid>
         {windowSize.width <= 960 && (

--- a/src/components/NavBar/new/MiniNavbar/index.jsx
+++ b/src/components/NavBar/new/MiniNavbar/index.jsx
@@ -33,7 +33,11 @@ const useStyles = makeStyles(theme => ({
     padding: "2px",
     border: "1px solid #ced4da",
     borderRadius: "0.8rem",
-    width: "100%"
+    width: "100%",
+    [theme.breakpoints.between("sm", "md")]: {
+      maxWidth: "60%",
+      margin: "0 auto"
+    }
   },
   icon: {
     padding: "2px",
@@ -137,7 +141,14 @@ function MiniNavbar() {
           justifyContent="space-between"
           alignItems="center"
         >
-          <Grid item xs={12} md={3} container alignItems="center">
+          <Grid
+            item
+            xs={12}
+            md={3}
+            container
+            alignItems="center"
+            sx={{ mb: { xs: 1, md: 0 } }}
+          >
             <Grid
               item
               style={{
@@ -286,53 +297,53 @@ function MiniNavbar() {
           toggleSlider={toggleSlider}
           notificationCount={notificationCount}
         >
-          {window.innerWidth <= 960 && (
-            <>
-              <Grid
-                item
+          {window.innerWidth <= 960 && [
+            <Grid
+              item
+              key="login-btn"
+              style={{
+                padding: 10
+              }}
+            >
+              <Button
+                variant="contained"
+                color="primary"
                 style={{
-                  padding: 10
+                  boxShadow: "none",
+                  color: "white"
+                }}
+                className={classes.button}
+                onClick={() => {
+                  toggleSlider();
+                  history.push("/login");
                 }}
               >
-                <Button
-                  variant="contained"
-                  color="primary"
-                  style={{
-                    boxShadow: "none",
-                    color: "white"
-                  }}
-                  className={classes.button}
-                  onClick={() => {
-                    toggleSlider();
-                    history.push("/login");
-                  }}
-                >
-                  Login
-                </Button>
-              </Grid>
-              <Grid
-                item
+                Login
+              </Button>
+            </Grid>,
+            <Grid
+              item
+              key="signup-btn"
+              style={{
+                padding: 10
+              }}
+            >
+              <Button
+                variant="outlined"
+                color="primary"
                 style={{
-                  padding: 10
+                  boxShadow: "none"
+                }}
+                className={classes.button}
+                onClick={() => {
+                  toggleSlider();
+                  history.push("/signup");
                 }}
               >
-                <Button
-                  variant="outlined"
-                  color="primary"
-                  style={{
-                    boxShadow: "none"
-                  }}
-                  className={classes.button}
-                  onClick={() => {
-                    toggleSlider();
-                    history.push("/signup");
-                  }}
-                >
-                  Sign Up
-                </Button>
-              </Grid>
-            </>
-          )}
+                Sign Up
+              </Button>
+            </Grid>
+          ]}
         </SideBar>
       )}
     </Headroom>

--- a/src/components/Tutorials/NewTutorial/index.jsx
+++ b/src/components/Tutorials/NewTutorial/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { AppstoreAddOutlined } from "@ant-design/icons";
 import { useDispatch, useSelector } from "react-redux";
 import { createTutorial, getProfileData } from "../../../store/actions";
@@ -20,6 +20,15 @@ import MovieIcon from "@mui/icons-material/Movie";
 import Select from "react-select";
 import { common } from "@mui/material/colors";
 import CloseIcon from "@mui/icons-material/Close";
+import {
+  LinearProgress,
+  List,
+  ListItem,
+  ListItemText,
+  ListItemSecondaryAction
+} from "@mui/material";
+import DeleteIcon from "@mui/icons-material/Delete";
+import InsertDriveFileIcon from "@mui/icons-material/InsertDriveFile";
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -65,6 +74,10 @@ const NewTutorial = ({ viewModal, onSidebarClick, viewCallback, active }) => {
     owner: "",
     tags: []
   });
+  const [mediaFiles, setMediaFiles] = useState([]);
+  const [uploadProgress, setUploadProgress] = useState(0);
+  const [uploading, setUploading] = useState(false);
+  const fileInputRef = React.useRef(null);
 
   const loadingProp = useSelector(
     ({
@@ -150,22 +163,66 @@ const NewTutorial = ({ viewModal, onSidebarClick, viewCallback, active }) => {
     setformValue({
       title: "",
       summary: "",
-      owner: "",
+      owner: userHandle || "",
       tags: []
     });
+    setMediaFiles([]);
     setVisible(viewModal);
-  }, [viewModal]);
+  }, [viewModal, userHandle]);
 
   const onSubmit = formData => {
     formData.preventDefault();
     const tutorialData = {
       ...formValue,
+      owner: formValue.owner || userHandle,
       created_by: userHandle,
       is_org: userHandle !== formValue.owner,
-      completed: false
+      completed: false,
+      mediaFiles: mediaFiles
     };
     console.log(tutorialData);
     createTutorial(tutorialData)(firebase, firestore, dispatch, history);
+  };
+
+  const handleFileUpload = async event => {
+    const file = event.target.files[0];
+    if (!file) return;
+
+    setUploading(true);
+    setUploadProgress(0);
+
+    const storagePath = `tutorials/media/${Date.now()}_${file.name}`;
+    const storageRef = firebase.storage().ref(storagePath);
+    const uploadTask = storageRef.put(file);
+
+    uploadTask.on(
+      "state_changed",
+      snapshot => {
+        const progress =
+          (snapshot.bytesTransferred / snapshot.totalBytes) * 100;
+        setUploadProgress(progress);
+      },
+      error => {
+        console.error("Upload failed", error);
+        setUploading(false);
+      },
+      async () => {
+        const downloadURL = await uploadTask.snapshot.ref.getDownloadURL();
+        const newMedia = {
+          name: file.name,
+          url: downloadURL,
+          type: file.type,
+          path: storagePath
+        };
+        setMediaFiles(prev => [...prev, newMedia]);
+        setUploading(false);
+        setUploadProgress(0);
+      }
+    );
+  };
+
+  const removeMedia = index => {
+    setMediaFiles(prev => prev.filter((_, i) => i !== index));
   };
 
   const onOwnerChange = value => {
@@ -203,6 +260,27 @@ const NewTutorial = ({ viewModal, onSidebarClick, viewCallback, active }) => {
   };
 
   const classes = useStyles();
+  const ownerOptions = useMemo(() => {
+    const options = [];
+    if (userHandle) {
+      options.push({
+        value: userHandle,
+        label: displayName || userHandle
+      });
+    }
+
+    if (orgList && orgList.length > 0) {
+      orgList.forEach(org => {
+        options.push({
+          value: org.org_handle,
+          label: org.org_name
+        });
+      });
+    }
+
+    return options;
+  }, [userHandle, displayName, orgList]);
+
   return (
     <Modal
       open={visible}
@@ -219,11 +297,12 @@ const NewTutorial = ({ viewModal, onSidebarClick, viewCallback, active }) => {
         data-testId="tutorialNewModal"
         style={{
           height: "auto",
-          width: "auto",
+          width: "min(40rem, 92vw)",
           background: "white",
           padding: "2rem",
           paddingTop: "1rem",
-          maxWidth: "40%"
+          maxHeight: "90vh",
+          overflowY: "auto"
         }}
       >
         {error && (
@@ -240,10 +319,11 @@ const NewTutorial = ({ viewModal, onSidebarClick, viewCallback, active }) => {
         >
           <Typography>
             <Select
-              options={organizations?.map(org => ({
-                value: org.org_handle,
-                label: org.org_name
-              }))}
+              options={ownerOptions}
+              value={
+                ownerOptions.find(option => option.value === formValue.owner) ||
+                null
+              }
               onChange={data => {
                 onOwnerChange(data.value);
               }}
@@ -312,15 +392,76 @@ const NewTutorial = ({ viewModal, onSidebarClick, viewCallback, active }) => {
             ))}
           </div>
 
-          <IconButton>
+          <input
+            type="file"
+            multiple={false}
+            ref={fileInputRef}
+            style={{ display: "none" }}
+            onChange={handleFileUpload}
+          />
+
+          <IconButton onClick={() => fileInputRef.current.click()}>
             <ImageIcon />
           </IconButton>
-          <IconButton>
+          <IconButton onClick={() => fileInputRef.current.click()}>
             <MovieIcon />
           </IconButton>
-          <IconButton>
+          <IconButton onClick={() => fileInputRef.current.click()}>
             <DescriptionIcon />
           </IconButton>
+
+          {uploading && (
+            <Box sx={{ width: "100%", mt: 1 }}>
+              <LinearProgress variant="determinate" value={uploadProgress} />
+            </Box>
+          )}
+
+          <List>
+            {mediaFiles.map((file, index) => (
+              <ListItem key={index}>
+                <Avatar sx={{ mr: 2 }}>
+                  {file.type.startsWith("image/") ? (
+                    <ImageIcon />
+                  ) : file.type.startsWith("video/") ? (
+                    <MovieIcon />
+                  ) : (
+                    <InsertDriveFileIcon />
+                  )}
+                </Avatar>
+                <ListItemText
+                  primary={file.name}
+                  secondary={file.type}
+                  primaryTypographyProps={{ noWrap: true }}
+                />
+                <Box sx={{ mr: 2, maxWidth: "120px" }}>
+                  {file.type.startsWith("image/") && (
+                    <img
+                      src={file.url}
+                      alt={file.name}
+                      style={{ width: "100%", borderRadius: "6px" }}
+                    />
+                  )}
+                  {file.type.startsWith("video/") && (
+                    <video
+                      src={file.url}
+                      controls
+                      style={{ width: "100%", borderRadius: "6px" }}
+                    />
+                  )}
+                  {file.type === "application/pdf" && (
+                    <a href={file.url} target="_blank" rel="noreferrer">
+                      Preview PDF
+                    </a>
+                  )}
+                </Box>
+                <ListItemSecondaryAction>
+                  <IconButton edge="end" onClick={() => removeMedia(index)}>
+                    <DeleteIcon />
+                  </IconButton>
+                </ListItemSecondaryAction>
+              </ListItem>
+            ))}
+          </List>
 
           <div className="mb-0">
             <div style={{ float: "right" }}>
@@ -333,7 +474,7 @@ const NewTutorial = ({ viewModal, onSidebarClick, viewCallback, active }) => {
                   setformValue({
                     title: "",
                     summary: "",
-                    owner: "",
+                    owner: userHandle || "",
                     tags: []
                   });
                 }}
@@ -361,7 +502,7 @@ const NewTutorial = ({ viewModal, onSidebarClick, viewCallback, active }) => {
                 disabled={
                   formValue.title === "" ||
                   formValue.summary === "" ||
-                  formValue.owner === ""
+                  (formValue.owner === "" && !userHandle)
                 }
               >
                 {loading ? "Creating..." : "Create"}

--- a/src/components/Tutorials/index.jsx
+++ b/src/components/Tutorials/index.jsx
@@ -1,13 +1,11 @@
 import React, { useState, useEffect } from "react";
 import Grid from "@mui/material/Grid";
-import { useMediaQuery } from "react-responsive";
+import { Box, useMediaQuery } from "@mui/material";
 import StepsPanel from "./subComps/StepsPanel";
-import ReactMarkdown from "react-markdown";
 import { TutorialTimeRemaining } from "../../helpers/tutorialTime";
 import ControlButtons from "./subComps/ControlButtons";
 import TutorialHeading from "./subComps/TutorialTitle";
 import EditControls from "./subComps/EditControls";
-import Editor from "../Editor";
 import ImageDrawer from "./subComps/ImageDrawer";
 import StepsTitle from "./subComps/StepsTitle";
 import { useDispatch, useSelector } from "react-redux";
@@ -23,13 +21,17 @@ import AddNewStepModal from "./subComps/AddNewStep";
 import QuillEditor from "../Editor/QuillEditor";
 import HtmlTextRenderer from "./subComps/HtmlTextRenderer";
 import { Collapse, Button } from "@mui/material";
+import Drawer from "@mui/material/Drawer";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { makeStyles } from "@mui/styles";
 
 const useStyles = makeStyles(theme => ({
   flexRow: {
     display: "flex",
-    flexDirection: "row"
+    flexDirection: "row",
+    [theme.breakpoints.down("sm")]: {
+      flexDirection: "column"
+    }
   },
   collapseContainer: {
     minWidth: "100%",
@@ -44,9 +46,21 @@ const useStyles = makeStyles(theme => ({
     transition: theme.transitions.create(["width"])
   },
   expandButton: {
-    display: "flex",
-    alignItems: "start",
-    paddingTop: "15px"
+    position: "fixed",
+    left: "10px",
+    top: "100px",
+    zIndex: 1100,
+    backgroundColor: "white",
+    boxShadow: "0px 2px 4px rgba(0,0,0,0.1)",
+    borderRadius: "50%",
+    padding: "8px",
+    minWidth: "auto",
+    "&:hover": {
+      backgroundColor: "#f5f5f5"
+    },
+    [theme.breakpoints.up("md")]: {
+      display: "none"
+    }
   },
   rotateChildren: {
     display: "flex",
@@ -57,13 +71,21 @@ const useStyles = makeStyles(theme => ({
     })
   },
   ExpandIcon: {
-    fontSize: 50
+    fontSize: 24,
+    color: "#03AAFA"
   },
   editorContainer: {
-    width: "100%",
-    padding: "0 10px 10px 10px",
+    flexGrow: 1,
+    padding: "16px",
+    [theme.breakpoints.down("md")]: {
+      padding: "12px"
+    },
+    [theme.breakpoints.down("sm")]: {
+      padding: "20px 8px"
+    },
     overflow: "hidden",
-    background: "white"
+    background: "white",
+    position: "relative"
   }
 }));
 
@@ -98,9 +120,7 @@ const ViewTutorial = () => {
   const [stepsData, setStepData] = useState(null);
   const [tutorialData, setTutorialData] = useState(null);
   const [expand, setExpand] = useState(true);
-  const isDesktop = useMediaQuery({
-    query: "(min-device-width: 767px)"
-  });
+  const isDesktop = useMediaQuery("(min-width: 900px)");
   const { owner, tutorial_id } = useParams();
   const classes = useStyles();
 
@@ -174,88 +194,132 @@ const ViewTutorial = () => {
   if (tutorialData) {
     window.scrollTo(0, 0);
     return (
-      <Grid className="row-footer-below">
+      <Grid container className="row-footer-below">
         {allowEdit && (
-          <Grid>
-            <Grid xs={24} sm={24} md={24}>
-              <EditControls
-                isPublished={tutorialData.isPublished}
-                stepPanelVisible={stepPanelVisible}
-                isDesktop={isDesktop}
-                noteID={stepsData[currentStep].id}
-                setMode={mode => setMode(mode)}
-                mode={mode}
-                toggleImageDrawer={() => setImageDrawerVisible(true)}
-                tutorial_id={tutorialData.tutorial_id}
-                toggleAddNewStep={() =>
-                  setAddNewStepModalVisible(!addNewStepModalVisible)
-                }
-                visibility={stepsData[currentStep].visibility}
-                owner={owner}
-                currentStep={currentStep}
-                step_length={stepsData.length}
-              />
-            </Grid>
+          <Grid item xs={12}>
+            <EditControls
+              isPublished={tutorialData.isPublished}
+              stepPanelVisible={stepPanelVisible}
+              expand={expand}
+              isDesktop={isDesktop}
+              noteID={stepsData[currentStep].id}
+              setMode={mode => setMode(mode)}
+              mode={mode}
+              toggleImageDrawer={() => setImageDrawerVisible(true)}
+              tutorial_id={tutorialData.tutorial_id}
+              toggleAddNewStep={() =>
+                setAddNewStepModalVisible(!addNewStepModalVisible)
+              }
+              visibility={stepsData[currentStep].visibility}
+              owner={owner}
+              currentStep={currentStep}
+              step_length={stepsData.length}
+            />
           </Grid>
         )}
 
-        <Grid>
-          <Grid xs={24} sm={24} md={24}>
-            <TutorialHeading
-              stepPanelVisible={stepPanelVisible}
-              isDesktop={isDesktop}
-              setStepPanelVisible={setStepPanelVisible}
-              tutorialData={tutorialData}
-              timeRemaining={timeRemaining}
-            />
-          </Grid>
+        <Grid item xs={12}>
+          <TutorialHeading
+            stepPanelVisible={stepPanelVisible}
+            isDesktop={isDesktop}
+            setStepPanelVisible={setStepPanelVisible}
+            tutorialData={tutorialData}
+            timeRemaining={timeRemaining}
+          />
         </Grid>
-        <Grid className={classes.flexRow}>
-          <ExpandMore
-            data-testid="tutorial-collapse-button"
-            expand={expand}
-            onClick={() => {
-              setExpand(prev => !prev);
-              setStepPanelVisible(prev => !prev);
-            }}
-            aria-expanded={expand}
-            aria-label="show more"
-          >
-            <ExpandMoreIcon className={classes.ExpandIcon} />
-          </ExpandMore>
+        <Grid
+          item
+          xs={12}
+          className={classes.flexRow}
+          sx={{ position: "relative" }}
+        >
+          {!isDesktop && (
+            <ExpandMore
+              data-testid="tutorial-collapse-button"
+              expand={expand}
+              onClick={() => {
+                setExpand(prev => !prev);
+                setStepPanelVisible(prev => !prev);
+              }}
+              aria-expanded={expand}
+              aria-label="show more"
+            >
+              <ExpandMoreIcon className={classes.ExpandIcon} />
+            </ExpandMore>
+          )}
 
-          <Grid
-            width={stepPanelVisible ? (isDesktop ? "55%" : "100%") : "0"}
-            padding={stepPanelVisible ? "0 2rem" : "0"}
-            className={classes.widthTransition}
-          >
-            <Collapse
-              data-testid="tutorial-steps-list"
-              in={expand}
-              timeout="auto"
-              unmountOnExit
-              orientation="horizontal"
-              className={classes.collapseContainer}
+          {isDesktop ? (
+            <Grid
+              item
+              sx={{
+                width: stepPanelVisible
+                  ? isDesktop
+                    ? "max(20%, 250px)"
+                    : "100%"
+                  : "0",
+                minWidth: stepPanelVisible
+                  ? isDesktop
+                    ? "250px"
+                    : "100%"
+                  : "0",
+                padding: stepPanelVisible ? "0" : "0",
+                display: stepPanelVisible ? "block" : "none",
+                overflow: "hidden",
+                transition: "width 0.3s"
+              }}
+              className={classes.widthTransition}
+            >
+              <Collapse
+                data-testid="tutorial-steps-list"
+                in={expand}
+                timeout="auto"
+                unmountOnExit
+                orientation="horizontal"
+                className={classes.collapseContainer}
+              >
+                <StepsPanel
+                  currentStep={currentStep}
+                  onChange={onChange}
+                  stepsData={stepsData}
+                  onClick={() => setStepPanelVisible(false)}
+                  hideButton={isDesktop}
+                  setCurrentStep={setCurrentStep}
+                  setStepData={setStepData}
+                />
+              </Collapse>
+            </Grid>
+          ) : (
+            <Drawer
+              anchor="left"
+              open={stepPanelVisible}
+              onClose={() => setStepPanelVisible(false)}
+              PaperProps={{
+                sx: { width: "80%", maxWidth: "300px" }
+              }}
             >
               <StepsPanel
                 currentStep={currentStep}
                 onChange={onChange}
                 stepsData={stepsData}
                 onClick={() => setStepPanelVisible(false)}
-                hideButton={isDesktop}
+                hideButton={false}
                 setCurrentStep={setCurrentStep}
                 setStepData={setStepData}
               />
-            </Collapse>
-          </Grid>
+            </Drawer>
+          )}
 
-          <Grid className={classes.editorContainer}>
-            <Grid className="tutorial-content" justify="center" container>
+          <Grid item sx={{ flexGrow: 1, overflow: "hidden" }}>
+            <Grid
+              className="tutorial-content"
+              justifyContent="center"
+              container
+            >
               <Grid
-                xs={24}
-                sm={24}
-                md={20}
-                lg={18}
+                item
+                xs={12}
+                md={10}
+                lg={9}
                 className="col-pad-24-s mt-24-od tutorial-paper"
                 style={{
                   display: "flex",
@@ -295,6 +359,15 @@ const ViewTutorial = () => {
                     )}
                   </>
                 )}
+                <Box sx={{ mt: 4, pt: 2, borderTop: "1px solid #eee" }}>
+                  <ControlButtons
+                    currentStep={currentStep}
+                    setCurrentStep={setCurrentStep}
+                    stepsData={stepsData}
+                    setStepData={setStepData}
+                    hide={false}
+                  />
+                </Box>
               </Grid>
               {imageDrawerVisible && (
                 <ImageDrawer

--- a/src/components/Tutorials/subComps/ColorPickerModal.jsx
+++ b/src/components/Tutorials/subComps/ColorPickerModal.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import Grid from "@mui/material/Grid";
+import Box from "@mui/material/Box";
 import Modal from "@mui/material/Modal";
 import { Panel as ColorPickerPanel } from "rc-color-picker";
 import "rc-color-picker/assets/index.css";
@@ -52,54 +53,48 @@ const ColorPickerModal = ({ visible, visibleCallback, tutorial_id, owner }) => {
           justifyContent: "center"
         }}
       >
-        <Grid>
-          <Grid align="middle" justify="center" className="mb-24">
-            <Grid
-              xs={24}
-              md={12}
-              className="mb-16"
-              style={{ textAlign: "center" }}
-            >
-              <h4 className="mb-8">Text Color</h4>
-              <div>
-                <ColorPickerPanel
-                  enableAlpha={false}
-                  onChange={updateTextColor}
-                  mode="RGB"
-                />
-              </div>
-            </Grid>
-            <Grid
-              xs={24}
-              md={12}
-              className="mb-16"
-              style={{ textAlign: "center" }}
-            >
-              <h4 className="mb-8">Background Color</h4>
-              <div>
-                <ColorPickerPanel
-                  enableAlpha={false}
-                  onChange={updateBackgroundColor}
-                  mode="RGB"
-                  align="center"
-                />
-              </div>
-            </Grid>
+        <Grid
+          container
+          spacing={2}
+          sx={{ p: 2, bgcolor: "white", borderRadius: 2 }}
+        >
+          <Grid item xs={12} sm={6} sx={{ textAlign: "center" }}>
+            <h4 className="mb-8">Text Color</h4>
+            <Box sx={{ display: "flex", justifyContent: "center" }}>
+              <ColorPickerPanel
+                enableAlpha={false}
+                onChange={updateTextColor}
+                mode="RGB"
+              />
+            </Box>
           </Grid>
-
+          <Grid item xs={12} sm={6} sx={{ textAlign: "center" }}>
+            <h4 className="mb-8">Background Color</h4>
+            <Box sx={{ display: "flex", justifyContent: "center" }}>
+              <ColorPickerPanel
+                enableAlpha={false}
+                onChange={updateBackgroundColor}
+                mode="RGB"
+                align="center"
+              />
+            </Box>
+          </Grid>
           <Grid
-            style={{
+            item
+            xs={12}
+            sx={{
               width: "100%",
               height: "50px",
               backgroundColor: bgColor,
               color: textColor,
-              border: "1px solid #eeeeee"
+              border: "1px solid #eeeeee",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              mt: 2
             }}
-            align="middle"
           >
-            <Grid xs={24} style={{ textAlign: "center" }}>
-              Change the values above to see the preview
-            </Grid>
+            Change the values above to see the preview
           </Grid>
         </Grid>
       </Modal>

--- a/src/components/Tutorials/subComps/ControlButtons.jsx
+++ b/src/components/Tutorials/subComps/ControlButtons.jsx
@@ -3,7 +3,7 @@ import Button from "@mui/material/Button";
 import Snackbar from "@mui/material/Snackbar";
 import Grid from "@mui/material/Grid";
 import { makeStyles } from "@mui/styles";
-import { Box } from "@mui/material";
+import { Box, Stack } from "@mui/material";
 
 const useStyles = makeStyles(theme => ({
   container: {
@@ -41,65 +41,85 @@ const ControlButtons = ({
   const classes = useStyles();
   if (!hide && stepsData) {
     return (
-      <Grid>
-        <Box className={classes.container}>
+      <Stack
+        direction={{ xs: "column", sm: "row" }}
+        sx={{
+          width: "100%",
+          justifyContent: "center",
+          alignItems: "center",
+          gap: { xs: 2, sm: 4 },
+          py: 2
+        }}
+      >
+        <Button
+          color="primary"
+          variant="outlined"
+          data-testid="previousStepButton"
+          onClick={() => {
+            setCurrentStep(currentStep - 1);
+            window.scrollTo(0, 0);
+          }}
+          disabled={currentStep === 0}
+          sx={{ minWidth: "120px", width: { xs: "100%", sm: "auto" } }}
+        >
+          Previous
+        </Button>
+        <Stack
+          direction={{ xs: "column", sm: "row" }}
+          spacing={2}
+          sx={{
+            width: { xs: "100%", sm: "auto" },
+            justifyContent: "center",
+            alignItems: "center",
+            gap: 2
+          }}
+        >
           <Button
+            variant="contained"
             color="primary"
-            variant="outlined"
-            data-testid="previousStepButton"
+            data-testid="nextStepButton"
             onClick={() => {
-              setCurrentStep(currentStep - 1);
+              setCurrentStep(currentStep + 1);
               window.scrollTo(0, 0);
             }}
-            disabled={currentStep === 0}
-            className={classes.prevButton}
+            disabled={currentStep >= stepsData.length - 1}
+            sx={{ minWidth: "120px", width: { xs: "100%", sm: "auto" } }}
           >
-            Previous
+            Next
           </Button>
-          <Box className={classes.rightButtonsGroup}>
-            <Button
-              variant="contained"
-              color="primary"
-              type="primary"
-              data-testid="nextStepButton"
-              onClick={() => {
-                setCurrentStep(currentStep + 1);
-                window.scrollTo(0, 0);
-              }}
-              disabled={currentStep >= stepsData.length - 1}
-            >
-              Next
-            </Button>
-            <Button
-              type="primary"
-              onClick={() => {
-                <Snackbar
-                  anchorOrigin={{
-                    vertical: "bottom",
-                    horizontal: "left"
-                  }}
-                  open={true}
-                  autoHideDuration={6000}
-                  message="tutorial complete"
-                />;
-                window.scrollTo(0, 0);
-                setStepData(prevSteps =>
-                  prevSteps.map((step, index) =>
-                    index === currentStep
-                      ? { ...step, completed: !step.completed }
-                      : step
-                  )
-                );
-              }}
-              className={classes.completeButton}
-            >
-              {stepsData[currentStep].completed
-                ? "Reset Step"
-                : "Complete Step"}
-            </Button>
-          </Box>
-        </Box>
-      </Grid>
+          <Button
+            variant="contained"
+            color="info"
+            onClick={() => {
+              <Snackbar
+                anchorOrigin={{
+                  vertical: "bottom",
+                  horizontal: "left"
+                }}
+                open={true}
+                autoHideDuration={6000}
+                message="tutorial complete"
+              />;
+              window.scrollTo(0, 0);
+              setStepData(prevSteps =>
+                prevSteps.map((step, index) =>
+                  index === currentStep
+                    ? { ...step, completed: !step.completed }
+                    : step
+                )
+              );
+            }}
+            sx={{
+              minWidth: "150px",
+              whiteSpace: "nowrap",
+              boxShadow: "none",
+              width: { xs: "100%", sm: "auto" }
+            }}
+          >
+            {stepsData[currentStep].completed ? "Reset Step" : "Complete Step"}
+          </Button>
+        </Stack>
+      </Stack>
     );
   } else return null;
 };

--- a/src/components/Tutorials/subComps/EditControls.jsx
+++ b/src/components/Tutorials/subComps/EditControls.jsx
@@ -21,11 +21,28 @@ import { useFirebase, useFirestore } from "react-redux-firebase";
 import { useDispatch } from "react-redux";
 import RemoveStepModal from "./RemoveStepModal";
 import ColorPickerModal from "./ColorPickerModal";
-import { Box, Stack } from "@mui/system";
+import { Box, Stack, IconButton } from "@mui/material";
+
+const actionButtonSx = {
+  minWidth: {
+    xs: "100%",
+    sm: "120px"
+  },
+  fontSize: {
+    xs: "0.85rem",
+    sm: "0.875rem"
+  },
+  whiteSpace: "nowrap",
+  textTransform: "none",
+  flexShrink: 0,
+  flexGrow: 1,
+  py: { xs: 1.5, sm: 1 }
+};
 
 const EditControls = ({
   isPublished,
   stepPanelVisible,
+  expand,
   isDesktop,
   setMode,
   noteID,
@@ -115,42 +132,67 @@ const EditControls = ({
 
   return (
     <>
-      <Stack
-        direction={"row"}
+      <Box
         sx={{
-          px: 2
+          display: "flex",
+          flexDirection: {
+            xs: "column",
+            sm: "row"
+          },
+          gap: 2,
+          px: 2,
+          py: 3,
+          width: "100%",
+          alignItems: "center",
+          justifyContent: "center",
+          flexWrap: "wrap",
+          borderBottom: "1px solid #f0f0f0",
+          backgroundColor: "#fff"
         }}
       >
         <Button
-          color="info"
+          color="primary"
           data-testid="addNewStep"
           variant="contained"
           sx={{
             boxShadow: "none",
-            borderRadius: 1
+            borderRadius: 1,
+            ...actionButtonSx,
+            width: { xs: "100%", sm: "auto" }
           }}
           onClick={() => toggleAddNewStep()}
+          startIcon={<AddIcon />}
         >
-          <AddIcon /> Add New Step
+          Add New Step
         </Button>
         <Button
-          className="ml-24"
           color="warning"
+          variant="outlined"
           onClick={() => toggleImageDrawer()}
           id="tutorialAddImg"
           startIcon={<InsertDriveFileIcon />}
+          sx={{
+            ...actionButtonSx,
+            width: { xs: "100%", sm: "auto" }
+          }}
         >
           Add images
         </Button>
-
         <Button
-          danger
+          variant="outlined"
+          sx={{
+            color: "rgba(0, 0, 0, 0.45)",
+            borderColor: "rgba(0, 0, 0, 0.15)",
+            ...actionButtonSx,
+            width: { xs: "100%", sm: "auto" }
+          }}
           onClick={() => {
             setViewRemoveStepModal(!viewRemoveStepModal);
           }}
           disabled={step_length === 1}
+          startIcon={<DeleteIcon />}
         >
-          <DeleteIcon /> Remove step
+          Remove step
           <RemoveStepModal
             owner={owner}
             tutorial_id={tutorial_id}
@@ -160,51 +202,61 @@ const EditControls = ({
             step_length={step_length}
           />
         </Button>
-        <Box
+
+        {mode === "edit" && (
+          <UserList tutorial_id={tutorial_id} noteID={noteID} />
+        )}
+
+        {mode === "view" ? (
+          <Button
+            color="primary"
+            variant="contained"
+            onClick={() => setMode("edit")}
+            id="editorMode"
+            data-testId="editorMode"
+            startIcon={<EditIcon />}
+            sx={{
+              ...actionButtonSx,
+              boxShadow: "none",
+              width: { xs: "100%", sm: "auto" }
+            }}
+          >
+            Editor mode
+          </Button>
+        ) : (
+          <Button
+            color="primary"
+            variant="contained"
+            onClick={() => setMode("view")}
+            data-testId="previewMode"
+            startIcon={<FileCopyIcon />}
+            sx={{
+              ...actionButtonSx,
+              boxShadow: "none",
+              width: { xs: "100%", sm: "auto" }
+            }}
+          >
+            Preview mode
+          </Button>
+        )}
+
+        <Button
+          data-testid="publishTutorial"
+          onClick={handlePublishTutorial}
+          variant="outlined"
+          color="primary"
+          disabled={publishLoad}
+          startIcon={<FileCopyIcon />}
           sx={{
-            flexGrow: 1
+            ...actionButtonSx,
+            width: { xs: "100%", sm: "auto" }
           }}
-        />
-        <div>
-          {!isDesktop && stepPanelVisible ? null : (
-            <>
-              {mode === "edit" && (
-                <UserList tutorial_id={tutorial_id} noteID={noteID} />
-              )}
-              {mode === "view" && (
-                <Button
-                  type="primary"
-                  className="ml-24"
-                  onClick={() => setMode("edit")}
-                  id="editorMode"
-                  data-testId="editorMode"
-                >
-                  <EditIcon /> Editor mode
-                </Button>
-              )}
-              {mode === "edit" && (
-                <Button
-                  type="primary"
-                  className="ml-24"
-                  onClick={() => setMode("view")}
-                  data-testId="previewMode"
-                >
-                  <FileCopyIcon /> Preview mode
-                </Button>
-              )}
-              <Button
-                data-testid="publishTutorial"
-                onClick={handlePublishTutorial}
-                type="dashed"
-                disabled={publishLoad}
-              >
-                <FileCopyIcon /> {isPublished ? "Unpublish" : "Publish"}
-              </Button>
-              <DropdownMenu key="more" />
-            </>
-          )}
-        </div>
-      </Stack>
+        >
+          {isPublished ? "Unpublish" : "Publish"}
+        </Button>
+
+        <DropdownMenu key="more" />
+      </Box>
       <ColorPickerModal
         visible={viewColorPickerModal}
         visibleCallback={e => setViewColorPickerModal(e)}

--- a/src/components/Tutorials/subComps/ImageDrawer.jsx
+++ b/src/components/Tutorials/subComps/ImageDrawer.jsx
@@ -1,9 +1,17 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import Button from "@mui/material/Button";
 import Drawer from "@mui/material/Drawer";
 import Grid from "@mui/material/Grid";
 import Snackbar from "@mui/material/Snackbar";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import LinearProgress from "@mui/material/LinearProgress";
 import { InboxOutlined, LoadingOutlined } from "@ant-design/icons";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import ErrorIcon from "@mui/icons-material/Error";
+import PictureAsPdfIcon from "@mui/icons-material/PictureAsPdf";
+import VideoLibraryIcon from "@mui/icons-material/VideoLibrary";
+import InsertDriveFileIcon from "@mui/icons-material/InsertDriveFile";
 import { useFirebase, useFirestore } from "react-redux-firebase";
 import { useDispatch, useSelector } from "react-redux";
 import {
@@ -24,6 +32,14 @@ const ImageDrawer = ({ onClose, visible, owner, tutorial_id, imageURLs }) => {
         images: { uploading }
       }
     }) => uploading
+  );
+
+  const progress = useSelector(
+    ({
+      tutorials: {
+        images: { progress }
+      }
+    }) => progress || {}
   );
 
   const uploading_error = useSelector(
@@ -50,53 +66,54 @@ const ImageDrawer = ({ onClose, visible, owner, tutorial_id, imageURLs }) => {
     }) => deleting_error
   );
 
-  useEffect(() => {
-    if (uploading === false && uploading_error === false) {
-      <Snackbar
-        anchorOrigin={{
-          vertical: "bottom",
-          horizontal: "left"
-        }}
-        open={true}
-        autoHideDuration={6000}
-        message="Image Uploaded successfully...."
-      />;
-    } else if (uploading === false && uploading_error) {
-      <Snackbar
-        anchorOrigin={{
-          vertical: "bottom",
-          horizontal: "left"
-        }}
-        open={true}
-        autoHideDuration={6000}
-        message={uploading_error}
-      />;
-    }
-  }, [uploading, uploading_error]);
+  const [snackbar, setSnackbar] = useState({
+    open: false,
+    message: ""
+  });
+
+  const [localUploads, setLocalUploads] = useState([]);
+
+  const drawerPaperSx = useMemo(
+    () => ({
+      width: {
+        xs: "80%",
+        sm: "30%",
+        md: "30%"
+      },
+      minWidth: { xs: "280px", sm: "350px" },
+      maxWidth: "100vw"
+    }),
+    []
+  );
 
   useEffect(() => {
-    if (deleting === false && deleting_error === false) {
-      <Snackbar
-        anchorOrigin={{
-          vertical: "bottom",
-          horizontal: "left"
-        }}
-        open={true}
-        autoHideDuration={6000}
-        message="Deleted Succefully...."
-      />;
-    } else if (deleting === false && deleting_error) {
-      <Snackbar
-        anchorOrigin={{
-          vertical: "bottom",
-          horizontal: "left"
-        }}
-        open={true}
-        autoHideDuration={6000}
-        message={deleting_error}
-      />;
+    if (uploading === false && uploading_error === false && visible) {
+      setSnackbar({
+        open: true,
+        message: "Uploads completed successfully."
+      });
+      setLocalUploads([]);
+    } else if (uploading === false && uploading_error) {
+      setSnackbar({
+        open: true,
+        message: uploading_error
+      });
     }
-  }, [deleting, deleting_error]);
+  }, [uploading, uploading_error, visible]);
+
+  useEffect(() => {
+    if (deleting === false && deleting_error === false && visible) {
+      setSnackbar({
+        open: true,
+        message: "Image deleted successfully."
+      });
+    } else if (deleting === false && deleting_error) {
+      setSnackbar({
+        open: true,
+        message: deleting_error
+      });
+    }
+  }, [deleting, deleting_error, visible]);
 
   useEffect(() => {
     clearTutorialImagesReducer()(dispatch);
@@ -105,107 +122,336 @@ const ImageDrawer = ({ onClose, visible, owner, tutorial_id, imageURLs }) => {
     };
   }, [dispatch]);
 
-  const props = {
-    name: "file",
-    multiple: true,
-    beforeUpload(file, files) {
-      uploadTutorialImages(owner, tutorial_id, files)(
+  const validateAndUpload = files => {
+    if (!files || files.length === 0) return;
+    const fileArray = Array.from(files);
+    const newUploads = fileArray.map(file => {
+      let error = null;
+      if (file.size > 10 * 1024 * 1024) error = "File exceeds 10MB limit";
+
+      const allowedTypes = ["image/", "video/", "application/pdf"];
+      if (!allowedTypes.some(type => file.type.startsWith(type))) {
+        error = "Only images, videos and PDFs supported";
+      }
+
+      return {
+        file,
+        name: file.name,
+        size: (file.size / 1024).toFixed(1) + " KB",
+        preview: file.type.startsWith("image/")
+          ? URL.createObjectURL(file)
+          : null,
+        type: file.type,
+        error
+      };
+    });
+
+    setLocalUploads(prev => [...prev, ...newUploads]);
+
+    const validFiles = newUploads.filter(f => !f.error).map(f => f.file);
+    if (validFiles.length > 0) {
+      uploadTutorialImages(owner, tutorial_id, validFiles)(
         firebase,
         firestore,
         dispatch
       );
-      return false;
     }
   };
 
-  const deleteFile = (name, url) =>
-    remoteTutorialImages(
-      owner,
-      tutorial_id,
-      name,
-      url
-    )(firebase, firestore, dispatch);
+  const deleteFile = item =>
+    remoteTutorialImages(owner, tutorial_id, item)(
+      firebase,
+      firestore,
+      dispatch
+    );
+
+  const setAsFeatured = async url => {
+    try {
+      await firestore.collection("tutorials").doc(tutorial_id).update({
+        featured_image: url,
+        updatedAt: firestore.FieldValue.serverTimestamp()
+      });
+      setSnackbar({
+        open: true,
+        message: "Featured image updated."
+      });
+    } catch (error) {
+      setSnackbar({
+        open: true,
+        message: error?.message || "Failed to set featured image."
+      });
+    }
+  };
+
+  const FileIcon = ({ type }) => {
+    if (type.startsWith("image/")) return null;
+    if (type.includes("pdf"))
+      return <PictureAsPdfIcon sx={{ fontSize: 40, color: "#f44336" }} />;
+    if (type.startsWith("video/"))
+      return <VideoLibraryIcon sx={{ fontSize: 40, color: "#2196f3" }} />;
+    return <InsertDriveFileIcon sx={{ fontSize: 40, color: "#9e9e9e" }} />;
+  };
 
   return (
-    <Drawer
-      title="Images"
-      data-testid="imageDrawer"
-      anchor="right"
-      closable={true}
-      onClose={onClose}
-      open={visible}
-      getContainer={true}
-      style={{ position: "absolute" }}
-      width="400px"
-      className="image-drawer"
-      destroyOnClose={true}
-      maskClosable={false}
-    >
-      <div className="col-pad-24" data-testId="tutorialImgUpload">
-        <Grid>
-          <input
-            id="file-upload"
-            fullWidth
-            accept="image/*"
-            type="file"
-            {...props}
-          />
-          {uploading ? (
-            <>
-              <LoadingOutlined /> Please wait...
-              <p className="ant-upload-hint mt-8">Uploading image(s)...</p>
-            </>
-          ) : (
-            <>
-              <p className="ant-upload-drag-icon">
-                <InboxOutlined />
-              </p>
-              <p className="ant-upload-text">
-                Click or drag images to here to upload
-              </p>
-            </>
-          )}
-        </Grid>
-        {imageURLs &&
-          imageURLs.length > 0 &&
-          imageURLs.map((image, i) => (
-            <Grid className="mb-24" key={i}>
-              <Grid xs={24} md={8}>
-                <img src={image.url} alt="" />
-              </Grid>
-              <Grid xs={24} md={16} className="pl-8" style={{}}>
-                <h4 className="pb-8">{image.name}</h4>
+    <>
+      <Drawer
+        data-testid="imageDrawer"
+        anchor="right"
+        onClose={onClose}
+        open={visible}
+        ModalProps={{ keepMounted: true }}
+        PaperProps={{ sx: drawerPaperSx }}
+      >
+        <Box
+          className="col-pad-24"
+          data-testId="tutorialImgUpload"
+          sx={{ py: 2, height: "100%", overflowY: "auto" }}
+        >
+          <Typography variant="h6" sx={{ mb: 2, fontWeight: 600 }}>
+            Manage Media
+          </Typography>
 
-                <CopyToClipboard
-                  text={`![alt=image; scale=1.0](${image.url})`}
-                  onCopy={() => (
-                    <Snackbar
-                      anchorOrigin={{
-                        vertical: "bottom",
-                        horizontal: "left"
+          <Box
+            component="label"
+            htmlFor="file-upload"
+            onDragOver={event => event.preventDefault()}
+            onDrop={event => {
+              event.preventDefault();
+              validateAndUpload(event.dataTransfer.files);
+            }}
+            sx={{
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              justifyContent: "center",
+              border: "2px dashed #2894ff",
+              borderRadius: "4px",
+              cursor: "pointer",
+              py: 3,
+              px: 2,
+              color: "#2894ff",
+              textAlign: "center",
+              mb: 2,
+              transition: "background 0.3s",
+              "&:hover": { background: "rgba(40, 148, 255, 0.05)" }
+            }}
+          >
+            <input
+              id="file-upload"
+              accept="image/*,video/*,application/pdf"
+              type="file"
+              multiple
+              style={{ display: "none" }}
+              onChange={event => {
+                validateAndUpload(event.target.files);
+                event.target.value = "";
+              }}
+            />
+            <Typography component="div" sx={{ fontSize: "2rem", mb: 1 }}>
+              <InboxOutlined />
+            </Typography>
+            <Typography sx={{ fontWeight: 500 }}>
+              Drop files here or click to upload
+            </Typography>
+            <Typography
+              variant="caption"
+              sx={{ color: "text.secondary", mt: 1 }}
+            >
+              Max 10MB per file (Images, Videos, PDFs)
+            </Typography>
+          </Box>
+
+          {localUploads.map((up, idx) => {
+            const fileProgress = progress[up.name] || 0;
+            const isDone = fileProgress === 100;
+
+            return (
+              <Box
+                key={idx}
+                sx={{
+                  mb: 2,
+                  p: 2,
+                  border: "1px solid #eee",
+                  borderRadius: "8px"
+                }}
+              >
+                <Box
+                  sx={{ display: "flex", alignItems: "center", gap: 2, mb: 1 }}
+                >
+                  {up.preview ? (
+                    <Box
+                      component="img"
+                      src={up.preview}
+                      sx={{
+                        width: 40,
+                        height: 40,
+                        objectFit: "cover",
+                        borderRadius: "4px"
                       }}
-                      open={true}
-                      autoHideDuration={6000}
-                      message="Copied...."
                     />
+                  ) : (
+                    <FileIcon type={up.type} />
                   )}
-                >
-                  <Button type="primary">Copy URL</Button>
-                </CopyToClipboard>
+                  <Box sx={{ flex: 1, overflow: "hidden" }}>
+                    <Typography variant="body2" noWrap sx={{ fontWeight: 600 }}>
+                      {up.name}
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      {up.size}
+                    </Typography>
+                  </Box>
+                  {isDone ? (
+                    <CheckCircleIcon color="success" fontSize="small" />
+                  ) : up.error ? (
+                    <ErrorIcon color="error" fontSize="small" />
+                  ) : (
+                    <LoadingOutlined style={{ color: "#2894ff" }} />
+                  )}
+                </Box>
 
-                <Button
-                  loading={deleting}
-                  onClick={() => deleteFile(image.name, image.url)}
-                  type="ghost"
-                  danger
+                {up.error ? (
+                  <Typography
+                    variant="caption"
+                    color="error"
+                    sx={{ mt: 0.5, display: "block" }}
+                  >
+                    {up.error}
+                  </Typography>
+                ) : (
+                  !isDone && (
+                    <Box sx={{ width: "100%", mt: 1 }}>
+                      <LinearProgress
+                        variant="determinate"
+                        value={fileProgress}
+                        sx={{ height: 6, borderRadius: 3 }}
+                      />
+                      <Typography
+                        variant="caption"
+                        sx={{ mt: 0.5, display: "block", textAlign: "right" }}
+                      >
+                        Uploading... {Math.round(fileProgress)}%
+                      </Typography>
+                    </Box>
+                  )
+                )}
+                {isDone && (
+                  <Typography
+                    variant="caption"
+                    color="success.main"
+                    sx={{ fontWeight: 600 }}
+                  >
+                    Upload complete
+                  </Typography>
+                )}
+              </Box>
+            );
+          })}
+
+          <Typography variant="subtitle2" sx={{ mt: 4, mb: 1, opacity: 0.7 }}>
+            Uploaded Media ({imageURLs?.length || 0})
+          </Typography>
+
+          {imageURLs &&
+            imageURLs.length > 0 &&
+            imageURLs.map((image, i) => {
+              const url =
+                typeof image === "string"
+                  ? image
+                  : image?.url || image?.downloadURL;
+              const name =
+                typeof image === "string" ? "Image" : image?.name || "Image";
+              const type = image?.type || "image/png";
+              if (!url) return null;
+
+              return (
+                <Grid
+                  key={i}
+                  sx={{
+                    display: "flex",
+                    gap: 2,
+                    alignItems: "flex-start",
+                    border: "1px solid #eee",
+                    borderRadius: "8px",
+                    p: 1.5,
+                    mt: 1.5,
+                    flexWrap: "nowrap"
+                  }}
                 >
-                  Delete
-                </Button>
-              </Grid>
-            </Grid>
-          ))}
-      </div>
-    </Drawer>
+                  <Box
+                    sx={{
+                      width: 60,
+                      height: 60,
+                      flexShrink: 0,
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      background: "#f9f9f9",
+                      borderRadius: "4px",
+                      overflow: "hidden"
+                    }}
+                  >
+                    {type.startsWith("image/") ? (
+                      <Box
+                        component="img"
+                        src={url}
+                        alt={name}
+                        onError={e => {
+                          e.target.src =
+                            "https://via.placeholder.com/60?text=File";
+                        }}
+                        sx={{
+                          width: "100%",
+                          height: "100%",
+                          objectFit: "cover"
+                        }}
+                      />
+                    ) : (
+                      <FileIcon type={type} />
+                    )}
+                  </Box>
+                  <Box sx={{ flex: 1, overflow: "hidden" }}>
+                    <Typography variant="body2" sx={{ fontWeight: 600 }} noWrap>
+                      {name}
+                    </Typography>
+                    <Box sx={{ display: "flex", gap: 1, mt: 1 }}>
+                      <CopyToClipboard
+                        text={
+                          type.startsWith("image/")
+                            ? `![alt=image; scale=1.0](${url})`
+                            : `[${name}](${url})`
+                        }
+                        onCopy={() =>
+                          setSnackbar({ open: true, message: "Copied Link." })
+                        }
+                      >
+                        <Button size="small" sx={{ fontSize: "0.65rem", p: 0 }}>
+                          COPY LINK
+                        </Button>
+                      </CopyToClipboard>
+                      <Button
+                        size="small"
+                        color="error"
+                        disabled={deleting}
+                        onClick={() => deleteFile(image)}
+                        sx={{ fontSize: "0.65rem", p: 0 }}
+                      >
+                        DELETE
+                      </Button>
+                    </Box>
+                  </Box>
+                </Grid>
+              );
+            })}
+        </Box>
+      </Drawer>
+      <Snackbar
+        anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
+        open={snackbar.open}
+        autoHideDuration={3000}
+        onClose={() => setSnackbar({ open: false, message: "" })}
+        message={snackbar.message}
+      />
+    </>
   );
 };
 

--- a/src/components/Tutorials/subComps/StepsPanel.jsx
+++ b/src/components/Tutorials/subComps/StepsPanel.jsx
@@ -12,12 +12,25 @@ import ControlButtons from "./ControlButtons";
 
 const useStyles = makeStyles({
   stepperContainer: {
-    width: "90%"
+    width: "100%",
+    padding: "20px 0"
   },
   stepButtonStyle: {
-    padding: "8px 16px",
-    borderRadius: 20,
-    backgroundColor: grey[100]
+    padding: "12px 20px",
+    borderRadius: 8,
+    backgroundColor: "#fff",
+    border: "1px solid #e8e8e8",
+    "&:hover": {
+      backgroundColor: grey[50],
+      borderColor: "#2894ff"
+    },
+    width: "100%",
+    textAlign: "left",
+    justifyContent: "flex-start",
+    boxShadow: "0 1px 3px rgba(0,0,0,0.05)"
+  },
+  stepItem: {
+    marginBottom: "16px"
   }
 });
 
@@ -33,15 +46,9 @@ const StepsPanel = ({
   const classes = useStyles();
   return (
     <Box className="tutorial-steps-sider" sx={theme => ({ p: 1 })}>
-      <Grid>
-        <Grid xs={24} sm={24} md={24} className="col-pad-24-s">
-          <ControlButtons
-            currentStep={currentStep}
-            setCurrentStep={setCurrentStep}
-            stepsData={stepsData}
-            setStepData={setStepData}
-            hide={!hideButton}
-          />
+      <Grid container>
+        <Grid item xs={12} className="col-pad-24-s">
+          {/* ControlButtons moved to main content area */}
         </Grid>
       </Grid>
       {!hideButton &&
@@ -67,7 +74,11 @@ const StepsPanel = ({
         {stepsData &&
           stepsData.map((step, index) => {
             return (
-              <Step key={"step" + step.id} completed={step.completed}>
+              <Step
+                key={"step" + step.id}
+                completed={step.completed}
+                className={classes.stepItem}
+              >
                 <StepButton
                   className={classes.stepButtonStyle}
                   onClick={() => {
@@ -75,7 +86,6 @@ const StepsPanel = ({
                   }}
                 >
                   {step.title}
-                  {step.visibility}
                 </StepButton>
               </Step>
             );

--- a/src/components/Tutorials/subComps/StepsTitle.jsx
+++ b/src/components/Tutorials/subComps/StepsTitle.jsx
@@ -114,32 +114,35 @@ const StepsTitle = ({ owner, tutorial_id }) => {
   };
 
   return (
-    <Grid>
-      <Grid xs={24}>
-        <form>
-          <Grid style={{ width: "100%" }}>
-            <Grid xs={24} md={19}>
+    <Grid container>
+      <Grid item xs={12}>
+        <form style={{ width: "100%" }}>
+          <Grid
+            container
+            spacing={1}
+            sx={{ width: "100%", alignItems: "center" }}
+          >
+            <Grid item xs={12} md={9}>
               <Input
                 onChange={e => setNewStepTitle(e.target.value)}
                 value={newStepTitle}
                 onBlur={setStepTitle}
                 placeholder="Title of the step"
                 className="tutorial-title-input"
-                size="large"
+                sx={{ width: "100%", fontSize: "1.2rem" }}
                 prefix={current_step_no + 1 + "."}
                 type="text"
                 data-testid={"stepTitleInput"}
               />
             </Grid>
-            <Grid xs={24} md={5}>
+            <Grid item xs={12} md={3}>
               <Input
                 onChange={e => setNewStepTime(parseInt(e.target.value) || 1)}
                 value={newStepTime}
                 onBlur={setStepTime}
                 placeholder="Time"
-                style={{ width: "100%" }}
+                sx={{ width: "100%" }}
                 className="tutorial-title-input"
-                size="large"
                 type="number"
                 suffix="minutes"
                 name="step_time"

--- a/src/components/Tutorials/subComps/TutorialTitle.jsx
+++ b/src/components/Tutorials/subComps/TutorialTitle.jsx
@@ -1,13 +1,10 @@
-import React from "react";
 import Button from "@mui/material/Button";
 import Tooltip from "@mui/material/Tooltip";
-import Grid from "@mui/material/Grid";
 import QueryBuilderIcon from "@mui/icons-material/QueryBuilder";
 import FullscreenIcon from "@mui/icons-material/Fullscreen";
 import FullscreenExitIcon from "@mui/icons-material/FullscreenExit";
-import { useState } from "react";
-import { Typography } from "@mui/material";
-import { set } from "lodash";
+import React, { useState } from "react";
+import { Typography, Stack, Box, IconButton } from "@mui/material";
 
 const TutorialHeading = ({
   stepPanelVisible,
@@ -34,60 +31,68 @@ const TutorialHeading = ({
   };
 
   return (
-    <Grid
-      style={{
+    <Box
+      sx={{
         display: "flex",
-        flexDirection: "row",
-        justifyContent: "space-around",
-        alignItems: "center"
+        flexDirection: "column",
+        justifyContent: "center",
+        alignItems: "center",
+        py: { xs: 3, sm: 2 },
+        px: { xs: 1, sm: 2 },
+        gap: 1
       }}
     >
       <Typography
         data-testid="tutorialTitle"
-        variant="h5"
+        variant="h4"
         sx={{
-          pt: 2,
-          pb: 2
+          fontWeight: 700,
+          textAlign: "center"
         }}
       >
         {tutorialData.title}
       </Typography>
       {!isDesktop && stepPanelVisible ? null : (
-        <>
-          <Grid>
-            <Button type="text" className="p-0">
-              <QueryBuilderIcon style={{ ...styleProps }} />{" "}
-              <span style={{ ...styleProps }}>
-                {timeRemaining} mins remaining
-              </span>
-            </Button>
-            {Fullscreen ? (
-              <Tooltip placement="left" title={"exit Fullscreen"}>
-                <Button
-                  type="dashed"
-                  onClick={toggleFullscreen}
-                  className="bp-8"
-                  style={{ ...styleProps }}
-                >
-                  <FullscreenExitIcon />
-                </Button>
-              </Tooltip>
-            ) : (
-              <Tooltip placement="left" title={"Go Fullscreen"}>
-                <Button
-                  type="dashed"
-                  onClick={toggleFullscreen}
-                  className="bp-8"
-                  style={{ ...styleProps }}
-                >
-                  <FullscreenIcon />
-                </Button>
-              </Tooltip>
-            )}
-          </Grid>
-        </>
+        <Stack
+          direction="row"
+          spacing={1}
+          alignItems="center"
+          justifyContent="center"
+        >
+          <Button
+            type="text"
+            className="p-0"
+            sx={{
+              ...styleProps,
+              textTransform: "none",
+              pointerEvents: "none"
+            }}
+          >
+            <QueryBuilderIcon sx={{ mr: 1 }} />
+            <span>{timeRemaining} mins remaining</span>
+          </Button>
+          {Fullscreen ? (
+            <Tooltip placement="left" title={"exit Fullscreen"}>
+              <IconButton
+                onClick={toggleFullscreen}
+                sx={{ ...styleProps, border: "1px dashed" }}
+              >
+                <FullscreenExitIcon />
+              </IconButton>
+            </Tooltip>
+          ) : (
+            <Tooltip placement="left" title={"Go Fullscreen"}>
+              <IconButton
+                onClick={toggleFullscreen}
+                sx={{ ...styleProps, border: "1px dashed" }}
+              >
+                <FullscreenIcon />
+              </IconButton>
+            </Tooltip>
+          )}
+        </Stack>
       )}
-    </Grid>
+    </Box>
   );
 };
 


### PR DESCRIPTION
## Pre-GSoC 2026 — GitHub Task 1: UI Improvement and Responsiveness

## Description
- **Tutorial Editor [EditControls.jsx]**: Refactored toolbar into a single centered flex row with responsive wrapping.
- **Steps Sidebar [StepsPanel.jsx]**: Updated buttons with card styling and borders for better visibility.
- **Breakpoints**: Optimized layout for 320px (stacked), 768px (centered), and 1024px+ (normalized).
- **Hardcoded values**: Replaced fixed padding and sidebar widths with dynamic [sx] properties.

## Related Issue
Pre-GSoC 2026 Tasks: c2siorg/Codelabz#283

## Motivation and Context
Fixed cramped UI and overlapping buttons on mobile and tablets. Improved creator UX by ensuring editor tools are accessible on all screen sizes.

## How Has This Been Tested?
- Verified at 320px, 768px, 1024px widths.
- Tested Step navigation and Publish flows.
- `npm run build` & `npm run lint`: Success.

## Screenshots

### **Before**
<img width="768" height="409" alt="before 1" src="https://github.com/user-attachments/assets/f932eb30-171a-4f4b-97eb-25f45f001160" />
<img width="195" height="338" alt="before" src="https://github.com/user-attachments/assets/b9764ad1-8159-4fb5-a006-d1508f1eb9e2" />

### **After**  
<img width="614" height="398" alt="after" src="https://github.com/user-attachments/assets/c11db735-dde1-406a-bc92-d3e940391c73" />
<img width="224" height="377" alt="task 1 2" src="https://github.com/user-attachments/assets/aee0fa63-91f5-46b3-ac87-f4ecd18872cf" />

## Types of changes
- [x] New feature
- [ ] Bug fix

## Checklist
- [x] My code follows the code style of this project
- [x] All new and existing tests passed