### PR TITLE
fix: add meaningful alt text to img elements for accessibility

### DIFF
--- a/src/components/Card/CardWithPicture.jsx
+++ b/src/components/Card/CardWithPicture.jsx
@@ -105,7 +105,7 @@ export default function CardWithPicture({ tutorial }) {
         avatar={
           <Avatar className={classes.avatar}>
             {user?.photoURL && user?.photoURL.length > 0 ? (
-              <img src={user?.photoURL} />
+              <img src={user?.photoURL} alt={user?.displayName ? `${user.displayName}'s avatar` : "User avatar"} />
             ) : (
               user?.displayName[0]
             )}

--- a/src/components/Card/CardWithoutPicture.jsx
+++ b/src/components/Card/CardWithoutPicture.jsx
@@ -91,7 +91,7 @@ export default function CardWithoutPicture({ tutorial }) {
         avatar={
           <Avatar className={classes.avatar}>
             {user?.photoURL && user?.photoURL.length > 0 ? (
-              <img src={user?.photoURL} />
+              <img src={user?.photoURL} alt={user?.displayName ? `${user.displayName}'s avatar` : "User avatar"} />
             ) : (
               user?.displayName[0]
             )}

--- a/src/components/CardTabs/Events/index.jsx
+++ b/src/components/CardTabs/Events/index.jsx
@@ -59,6 +59,7 @@ const EventsCard = props => {
                 <Grid item xs={3}>
                   <img
                     src={event.img[0]}
+                    alt={event.name || "Event logo"}
                     className={classes.logo}
                     data-testId={index == 0 ? "upEventImg" : ""}
                   />

--- a/src/components/CardTabs/Users/UserElement.jsx
+++ b/src/components/CardTabs/Users/UserElement.jsx
@@ -65,6 +65,7 @@ const UserElement = ({ user, index, useStyles }) => {
       >
         <img
           src={user.img[0]}
+          alt={user.name ? `${user.name}'s profile picture` : "User profile picture"}
           className={classes.userImg}
           data-testId={index == 0 ? "UsersCardImg" : ""}
         />

--- a/src/components/CodelabCard/index.jsx
+++ b/src/components/CodelabCard/index.jsx
@@ -54,7 +54,7 @@ const CardComponent = ({
                     />
                     <img
                       src={require(`../../assets/images/${profilePic}`).default}
-                      alt=""
+                      alt="Author profile picture"
                       height="20rem"
                       width="20rem"
                       className={classes.personImg}
@@ -64,7 +64,7 @@ const CardComponent = ({
               ) : (
                 <img
                   src={require(`../../assets/images/${profilePic}`).default}
-                  alt=""
+                  alt="Author profile picture"
                   className={classes.avatar}
                 />
               )}

--- a/src/components/ProfileBanner/profile/ProfileCardTwo/index.jsx
+++ b/src/components/ProfileBanner/profile/ProfileCardTwo/index.jsx
@@ -23,6 +23,7 @@ export default function ProfileCardTwo({
               <img
                 className={classes.profileUserImg}
                 src={profileImage}
+                alt={name ? `${name}'s profile picture` : "User profile picture"}
                 data-testId="user_profile_card_two_avatar"
               />
             </div>

--- a/src/components/SideBar/sidelist.jsx
+++ b/src/components/SideBar/sidelist.jsx
@@ -121,14 +121,14 @@ const SideList = ({
                             classes={{ badge: classes.customBadge }}
                           >
                             <img
-                              alt={"..."}
+                              alt={item.name || "Menu icon"}
                               src={item.img}
                               className={classes.icons}
                             />
                           </Badge>
                         ) : (
                           <img
-                            alt={"..."}
+                            alt={item.name || "Menu icon"}
                             src={item.img}
                             className={classes.icons}
                           />
@@ -200,7 +200,7 @@ const SideList = ({
                   {item.img && (
                     <ListItemIcon className={classes.listIcon}>
                       <img
-                        alt={"..."}
+                        alt={item.name || "Menu icon"}
                         src={item.img}
                         className={classes.icons}
                       />

--- a/src/components/TutorialPage/components/UserDetails.jsx
+++ b/src/components/TutorialPage/components/UserDetails.jsx
@@ -85,7 +85,7 @@ const User = ({ id, timestamp, size }) => {
             }}
           >
             {user?.photoURL && user?.photoURL.length > 0 ? (
-              <img src={user?.photoURL} />
+              <img src={user?.photoURL} alt={user?.displayName ? `${user.displayName}'s avatar` : "User avatar"} />
             ) : (
               user?.displayName[0]
             )}

--- a/src/components/Tutorials/subComps/ImageDrawer.jsx
+++ b/src/components/Tutorials/subComps/ImageDrawer.jsx
@@ -171,7 +171,7 @@ const ImageDrawer = ({ onClose, visible, owner, tutorial_id, imageURLs }) => {
           imageURLs.map((image, i) => (
             <Grid className="mb-24" key={i}>
               <Grid xs={24} md={8}>
-                <img src={image.url} alt="" />
+                <img src={image.url} alt={image.name || "Tutorial image"} />
               </Grid>
               <Grid xs={24} md={16} className="pl-8" style={{}}>
                 <h4 className="pb-8">{image.name}</h4>

--- a/src/components/util/CodelabCard/index.jsx
+++ b/src/components/util/CodelabCard/index.jsx
@@ -56,7 +56,7 @@ const CardComponent = ({
                       src={
                         require(`../../../assets/images/${profilePic}`).default
                       }
-                      alt=""
+                      alt="Author profile picture"
                       height="20rem"
                       width="20rem"
                       className={classes.personImg}
@@ -66,7 +66,7 @@ const CardComponent = ({
               ) : (
                 <img
                   src={require(`../../../assets/images/${profilePic}`).default}
-                  alt=""
+                  alt="Author profile picture"
                   className={classes.avatar}
                 />
               )}


### PR DESCRIPTION
## Description
Fixes missing and meaningless `alt` attributes on `<img>` elements across multiple components, improving accessibility and screen reader support throughout the application.

## Related Issue
Issue 

## Motivation and Context
Multiple `<img>` tags in the codebase either had no `alt` attribute, empty `alt=""`, or meaningless placeholder values like `alt={"..."}`. This violates WCAG accessibility guidelines and makes the application harder to use for users relying on assistive technologies. This fix ensures that:

- User avatar images have dynamic alt text based on the user's display name.
- Event and profile images have descriptive alt text.
- Sidebar menu icons use the menu item name as alt text.
- Tutorial images use the image filename as alt text.

## How Has This Been Tested?
- Verified the production build completes successfully with no errors.
- Ran the application locally with Firebase emulators and confirmed all pages load correctly.
- Manually reviewed all changed files to ensure alt text is descriptive and contextually appropriate.
- Confirmed no functional regressions were introduced.

## Screenshots or GIF (In case of UI changes):
N/A — no visual changes. Alt text is only visible to screen readers or when images fail to load.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
