### PR TITLE
fix: restrict Firestore and Storage security rules to require authentication

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -1,6 +1,20 @@
 {
   "rules": {
-    ".read": true,
-    ".write": true
+    "cl_user_presence": {
+      "$uid": {
+        ".read": "auth != null",
+        ".write": "auth != null && auth.uid === $uid"
+      }
+    },
+    "cl_user_sessions": {
+      "$uid": {
+        ".read": "auth != null",
+        ".write": "auth != null && auth.uid === $uid"
+      }
+    },
+    "$other": {
+      ".read": "auth != null",
+      ".write": "auth != null"
+    }
   }
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,8 +1,87 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
-    match /{document=**} {
-      allow read, write: if true;
+
+    // Helper: check if the request is from an authenticated user
+    function isAuthenticated() {
+      return request.auth != null;
+    }
+
+    // Helper: check if the authenticated user owns this resource
+    function isOwner(userId) {
+      return isAuthenticated() && request.auth.uid == userId;
+    }
+
+    // User profiles
+    match /cl_user/{userId} {
+      allow read: if isAuthenticated();
+      allow create: if isOwner(userId);
+      allow update: if isOwner(userId);
+      allow delete: if isOwner(userId);
+    }
+
+    // Organization general data
+    // Public read for published orgs, authenticated read for all,
+    // authenticated write for any logged-in user (org-level RBAC comes later)
+    match /cl_org_general/{orgHandle} {
+      allow read: if isAuthenticated() || resource.data.org_published == true;
+      allow create: if isAuthenticated();
+      allow update: if isAuthenticated();
+      allow delete: if isAuthenticated();
+    }
+
+    // Organization-user membership and permissions
+    match /org_users/{docId} {
+      allow read: if isAuthenticated();
+      allow write: if isAuthenticated();
+    }
+
+    // Organization subscribers
+    match /org_subscribers/{docId} {
+      allow read: if isAuthenticated();
+      allow write: if isAuthenticated();
+    }
+
+    // Tutorials — public read for published, authenticated write
+    match /tutorials/{tutorialId} {
+      allow read: if isAuthenticated() || resource.data.isPublished == true;
+      allow create: if isAuthenticated();
+      allow update: if isAuthenticated();
+      allow delete: if isAuthenticated();
+
+      // Tutorial steps (subcollection)
+      match /steps/{stepId} {
+        allow read: if isAuthenticated();
+        allow write: if isAuthenticated();
+      }
+    }
+
+    // Comments on tutorials — public read, authenticated write
+    match /cl_comments/{commentId} {
+      allow read: if true;
+      allow create: if isAuthenticated();
+      allow update: if isAuthenticated();
+      allow delete: if isAuthenticated();
+    }
+
+    // User follower relationships
+    match /user_followers/{docId} {
+      allow read: if isAuthenticated();
+      allow write: if isAuthenticated();
+    }
+
+    // Tag frequencies — public read, authenticated write
+    match /tag_frequencies/{tagId} {
+      allow read: if true;
+      allow write: if isAuthenticated();
+    }
+
+    // Notifications — only accessible by authenticated users
+    match /notifications/{notificationId} {
+      allow read: if isAuthenticated();
+      allow create: if isAuthenticated();
+      allow update: if isAuthenticated();
+      allow delete: if isAuthenticated();
     }
   }
 }

--- a/storage.rules
+++ b/storage.rules
@@ -1,8 +1,31 @@
 rules_version = '2';
 service firebase.storage {
   match /b/{bucket}/o {
-    match /{allPaths=**} {
-      allow read, write: if true;
+
+    // Allow public read for all files (images are displayed to all visitors)
+    // Require authentication for all uploads
+    // Restrict uploads to image files under 5MB
+
+    match /users/{userId}/{allPaths=**} {
+      allow read: if true;
+      allow write: if request.auth != null
+                   && request.auth.uid == userId
+                   && request.resource.size < 5 * 1024 * 1024
+                   && request.resource.contentType.matches('image/.*');
+    }
+
+    match /organizations/{orgHandle}/{allPaths=**} {
+      allow read: if true;
+      allow write: if request.auth != null
+                   && request.resource.size < 5 * 1024 * 1024
+                   && request.resource.contentType.matches('image/.*');
+    }
+
+    match /tutorials/{tutorialId}/{allPaths=**} {
+      allow read: if true;
+      allow write: if request.auth != null
+                   && request.resource.size < 5 * 1024 * 1024
+                   && request.resource.contentType.matches('image/.*');
     }
   }
 }


### PR DESCRIPTION
## Description
The current Firestore, Storage, and Realtime Database security rules all use `allow read, write: if true`, which permits **any unauthenticated user** to read, modify, or delete all data and files. This PR replaces the wildcard allow-all rules with collection-specific security rules that enforce authentication.

## Changes Made

### `firestore.rules`
- Replaced the single wildcard `allow read, write: if true` rule with per-collection rules
- **`cl_user/{userId}`**: Read requires authentication; create/update/delete restricted to the document owner (`request.auth.uid == userId`)
- **`cl_org_general/{orgHandle}`**: Public read for published orgs (`org_published == true`), authenticated read for all, authenticated write
- **`org_users/{docId}`**: Read and write require authentication
- **`org_subscribers/{docId}`**: Read and write require authentication
- **`tutorials/{tutorialId}`**: Public read for published tutorials (`isPublished == true`), authenticated write; nested `steps` subcollection requires authentication
- **`cl_comments/{commentId}`**: Public read (comments are visible to all), write requires authentication
- **`user_followers/{docId}`**: Read and write require authentication
- **`tag_frequencies/{tagId}`**: Public read, write requires authentication
- **`notifications/{notificationId}`**: Read and write require authentication
- Added `isAuthenticated()` and `isOwner(userId)` helper functions to reduce repetition

### `storage.rules`
- Replaced the single wildcard rule with path-specific rules for `users/`, `organizations/`, and `tutorials/`
- All paths allow public read (images are displayed to visitors)
- All uploads require authentication (`request.auth != null`)
- User profile image uploads restricted to the owning user (`request.auth.uid == userId`)
- All uploads enforce a **5MB file size limit** (`request.resource.size < 5 * 1024 * 1024`)
- All uploads restricted to **image content types** (`request.resource.contentType.matches('image/.*')`)

### `database.rules.json`
- Replaced root-level `".read": true, ".write": true` with path-specific rules
- **`cl_user_presence/{uid}`**: Read requires authentication; write restricted to owning user
- **`cl_user_sessions/{uid}`**: Read requires authentication; write restricted to owning user
- **`$other` (catch-all)**: Read and write require authentication

## Related Issue
Fixes a critical security vulnerability where Firestore, Storage, and Realtime Database rules allowed unrestricted unauthenticated access to all data.

## How to Test
1. Run Firebase emulators: `firebase emulators:start --import=testdata`
2. Try to write to Firestore without authentication — should be **denied**
3. Try to read a published tutorial without authentication — should **succeed**
4. Try to read user profile data without authentication — should be **denied**
5. Try to upload a file without authentication — should be **denied**
6. Try to upload a file > 5MB as an authenticated user — should be **denied**
7. Try to upload a non-image file as an authenticated user — should be **denied**

## Screenshots
N/A — backend security rules change