### PR TITLE
fix: configure pre-commit hook to use lint-staged and update prettierrc

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npm run lint
-npm run format
-
+npx lint-staged

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,23 +1,18 @@
 {
   "arrowParens": "avoid",
   "bracketSpacing": true,
-  "cursorOffset": -1,
-  "endOfLine": "auto",
+  "endOfLine": "lf",
   "htmlWhitespaceSensitivity": "css",
   "insertPragma": false,
-  "jsxBracketSameLine": false,
+  "bracketSameLine": false,
   "jsxSingleQuote": false,
-  "pluginSearchDirs": [],
-  "plugins": [],
   "printWidth": 80,
   "proseWrap": "preserve",
   "quoteProps": "as-needed",
-  "rangeStart": 0,
   "requirePragma": false,
   "semi": true,
   "singleQuote": false,
   "tabWidth": 2,
   "trailingComma": "none",
-  "useTabs": false,
-  "vueIndentScriptAndStyle": false
+  "useTabs": false
 }

--- a/package.json
+++ b/package.json
@@ -104,9 +104,10 @@
     "vite": "^5.2.12",
     "webpack": "^4.46.0"
   },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
+  "lint-staged": {
+    "src/**/*.{js,jsx}": [
+      "eslint --fix",
+      "prettier --write"
+    ]
   }
 }


### PR DESCRIPTION
## Description
The Husky pre-commit hook was running `npm run lint` and `npm run format` on the entire `src/` directory on every commit, regardless of which files were staged. This made commits slow and defeated the purpose of having `lint-staged` installed. Additionally, `.prettierrc` contained several deprecated settings from older Prettier versions.

## Changes Made

### `.husky/pre-commit`
Replaced full-directory lint and format with `npx lint-staged`, which only processes staged files.

**Before:**
```bash
npm run lint
npm run format
```

**After:**
```bash
npx lint-staged
```

### `package.json`
Replaced the obsolete Husky v4-style config (`"husky": { "hooks": ... }`) with a proper `lint-staged` configuration. Husky v8 ignores the old format entirely — it was dead config.

```json
"lint-staged": {
  "src/**/*.{js,jsx}": [
    "eslint --fix",
    "prettier --write"
  ]
}
```

### `.prettierrc`
Removed deprecated and invalid settings:
- `jsxBracketSameLine` → renamed to `bracketSameLine` (deprecated in Prettier v2.4)
- `cursorOffset: -1` → API-only option, invalid in config files
- `pluginSearchDirs: []` → removed in Prettier v3
- `plugins: []` → empty array is unnecessary
- `rangeStart: 0` → API-only option
- `vueIndentScriptAndStyle: false` → not relevant to this project
- `endOfLine: "auto"` → changed to `"lf"` for consistent line endings across OS

## How to Test
1. Stage a `.js` or `.jsx` file with a lint error (e.g., add an unused variable)
2. Run `git commit` — lint-staged should catch the error and abort
3. Stage a properly formatted file — commit should succeed
4. Verify `npx prettier --check .prettierrc` shows no config warnings