### PR TITLE
feat: add ErrorBoundary to prevent full-app crashes from component errors

### DIFF
--- a/src/components/ErrorPages/ErrorBoundary.jsx
+++ b/src/components/ErrorPages/ErrorBoundary.jsx
@@ -1,0 +1,74 @@
+import React from "react";
+import Grid from "@mui/material/Grid";
+import Typography from "@mui/material/Typography";
+import Button from "@mui/material/Button";
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    // Future: send to error reporting service
+    console.error("ErrorBoundary caught:", error, errorInfo);
+  }
+
+  handleReset = () => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <Grid
+          container
+          direction="column"
+          alignItems="center"
+          justifyContent="center"
+          style={{ minHeight: "60vh", textAlign: "center", padding: "2rem" }}
+        >
+          <Grid item>
+            <Typography variant="h4" gutterBottom>
+              Something went wrong
+            </Typography>
+          </Grid>
+          <Grid item>
+            <Typography
+              variant="body1"
+              color="textSecondary"
+              style={{ marginBottom: "1.5rem" }}
+            >
+              An unexpected error occurred. Please try again.
+            </Typography>
+          </Grid>
+          <Grid item>
+            <Button
+              variant="contained"
+              color="primary"
+              onClick={this.handleReset}
+              style={{ marginRight: "1rem" }}
+            >
+              Try Again
+            </Button>
+            <Button
+              variant="outlined"
+              color="primary"
+              onClick={() => (window.location.href = "/")}
+            >
+              Go Home
+            </Button>
+          </Grid>
+        </Grid>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -17,6 +17,7 @@ import AuthPage from "./components/AuthPage";
 import Dashboard from "./components/Dashboard";
 import Editor from "./components/Editor";
 import NotFound from "./components/ErrorPages/404";
+import ErrorBoundary from "./components/ErrorPages/ErrorBoundary";
 import HomePage from "./components/HomePage/index";
 import ManageUsers from "./components/ManageUsers";
 import MyFeed from "./components/MyFeed";
@@ -104,10 +105,11 @@ const AuthIsLoaded = ({ children }) => {
 const Routes = () => {
   return (
     <Router>
-      <AuthIsLoaded>
-        <CodeLabzAppBar />
-        {/* <Navbar /> */}
-        <Switch>
+      <ErrorBoundary>
+        <AuthIsLoaded>
+          <CodeLabzAppBar />
+          {/* <Navbar /> */}
+          <Switch>
           <Route exact path={"/"} component={HomePage} />
           <Route
             exact
@@ -190,10 +192,11 @@ const Routes = () => {
             path={"/notification"}
             component={UserIsAllowedUserDashboard(Notification)}
           />
-          <Route exact path={"*"} component={NotFound} />
-        </Switch>
-        {/* <Footer /> */}
-      </AuthIsLoaded>
+            <Route exact path={"*"} component={NotFound} />
+          </Switch>
+          {/* <Footer /> */}
+        </AuthIsLoaded>
+      </ErrorBoundary>
     </Router>
   );
 };


### PR DESCRIPTION
## Description
The application has no React Error Boundaries. Any unhandled JavaScript error in a component's render method crashes the entire React tree, resulting in a blank white screen with no way to recover except a full page refresh.

## Changes Made

### New: `src/components/ErrorPages/ErrorBoundary.jsx`
- Class component implementing `getDerivedStateFromError` and `componentDidCatch`
- Fallback UI with "Something went wrong" message, using existing MUI Grid/Typography/Button components
- "Try Again" button resets the error state, re-rendering the child tree
- "Go Home" button navigates to the root page
- `componentDidCatch` logs to console for now — ready for future error reporting integration

### Modified: `src/routes.jsx`
- Wrapped the route tree with `<ErrorBoundary>` inside `<Router>` but outside `<AuthIsLoaded>`
- This ensures page-level errors are caught without taking down the entire app shell

## How to Test
1. Start the app with `npm run dev`
2. Temporarily add `throw new Error("test")` inside any component's render (e.g., `MyFeed/index.jsx`)
3. Navigate to that page — should see the fallback UI instead of a blank screen
4. Click "Try Again" — component re-renders
5. Click "Go Home" — navigates to `/`
6. Remove the test error