### PR TITLE
fix: add descriptive alt text to images for WCAG accessibility

### DIFF
--- a/src/components/CodelabCard/index.jsx
+++ b/src/components/CodelabCard/index.jsx
@@ -54,7 +54,7 @@ const CardComponent = ({
                     />
                     <img
                       src={require(`../../assets/images/${profilePic}`).default}
-                      alt=""
+                      alt="Author profile picture"
                       height="20rem"
                       width="20rem"
                       className={classes.personImg}
@@ -64,7 +64,7 @@ const CardComponent = ({
               ) : (
                 <img
                   src={require(`../../assets/images/${profilePic}`).default}
-                  alt=""
+                  alt="Author avatar"
                   className={classes.avatar}
                 />
               )}

--- a/src/components/Tutorials/subComps/ImageDrawer.jsx
+++ b/src/components/Tutorials/subComps/ImageDrawer.jsx
@@ -171,7 +171,7 @@ const ImageDrawer = ({ onClose, visible, owner, tutorial_id, imageURLs }) => {
           imageURLs.map((image, i) => (
             <Grid className="mb-24" key={i}>
               <Grid xs={24} md={8}>
-                <img src={image.url} alt="" />
+                <img src={image.url} alt={image.name || "Tutorial image"} />
               </Grid>
               <Grid xs={24} md={16} className="pl-8" style={{}}>
                 <h4 className="pb-8">{image.name}</h4>

--- a/src/components/util/CodelabCard/index.jsx
+++ b/src/components/util/CodelabCard/index.jsx
@@ -56,7 +56,7 @@ const CardComponent = ({
                       src={
                         require(`../../../assets/images/${profilePic}`).default
                       }
-                      alt=""
+                      alt="Author profile picture"
                       height="20rem"
                       width="20rem"
                       className={classes.personImg}
@@ -66,7 +66,7 @@ const CardComponent = ({
               ) : (
                 <img
                   src={require(`../../../assets/images/${profilePic}`).default}
-                  alt=""
+                  alt="Author avatar"
                   className={classes.avatar}
                 />
               )}


### PR DESCRIPTION
## Summary
Replace empty `alt=""` attributes with descriptive alt text across 3 components to improve accessibility for screen reader users.

## Changes
| File | Before | After |
|------|--------|-------|
| `CodelabCard/index.jsx` | `alt=""` | `"Author profile picture"`, `"Author avatar"` |
| `ImageDrawer.jsx` | `alt=""` | `image.name \|\| "Tutorial image"` |
| `util/CodelabCard/index.jsx` | `alt=""` | `"Author profile picture"`, `"Author avatar"` |

## Test plan
- [ ] Screen reader announces descriptive text for profile images
- [ ] No visual changes to the UI

Closes #310