### PR TITLE
fix: Update broken deployment link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@
 
 # Deployment
 
-You can see the app live at [https://dev.codelabz.io/](https://dev.codelabz.io/)
+> ⚠️ **Note:** The live deployment is currently unavailable (DNS error).
+> Please set up the app locally using the [Contributing Guide](./CONTRIBUTING.md).
 
 # Community
 


### PR DESCRIPTION
## Description
Updated the broken deployment link in README.md. 
The live link https://dev.codelabz.io/ was returning 
a DNS error. Replaced it with a notice directing users 
to set up the app locally.

## Related Issue
Fixes #168

## Motivation and Context
The deployment link was broken and causing confusion 
for new contributors trying to preview the app. 
This fix improves the onboarding experience.

## How Has This Been Tested?
Verified that the README renders correctly on GitHub 
with the updated notice and working Contributing Guide link.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.