### PR TITLE
fix: fix missing authentication check in resendVerificationEmail cloud function

### DIFF
--- a/functions/cloud_functions/onCallFunctions.js
+++ b/functions/cloud_functions/onCallFunctions.js
@@ -1,8 +1,15 @@
 const functions = require("firebase-functions");
 const { db, admin } = require("../auth");
 
-exports.resendVerificationEmailHandler = async data => {
+exports.resendVerificationEmailHandler = async (data, context) => {
   try {
+    if (!context.auth) {
+      throw new functions.https.HttpsError(
+        "unauthenticated",
+        "The request must be authenticated."
+      );
+    }
+
     if (!data || !data.email) {
       console.log("Email is not defined");
       throw new functions.https.HttpsError(
@@ -48,10 +55,12 @@ exports.resendVerificationEmailHandler = async data => {
     return console.log(`Verification email sent to ${email}`);
   } catch (error) {
     console.log(error);
+    if (error instanceof functions.https.HttpsError) {
+      throw error;
+    }
     throw new functions.https.HttpsError(
-      "invalid-argument",
-      error.message,
-      error
+      "internal",
+      "An unexpected error occurred."
     );
   }
 };


### PR DESCRIPTION
## Summary

Adds missing authentication check to `resendVerificationEmailHandler` and fixes
the catch block that was overwriting intentional error codes.

Closes #373 

## Changes

### `functions/cloud_functions/onCallFunctions.js`

1. **Added `context` parameter** to handler signature and an `context.auth` guard
   that rejects unauthenticated requests with `"unauthenticated"` — matching the
   pattern already used by `sendPasswordUpdateEmailHandler` in the same file.

2. **Fixed catch block** to preserve already-constructed `HttpsError` instances
   (e.g. `"not-found"`, `"aborted"`) instead of re-wrapping every error as
   `"invalid-argument"`. Also removed the `error` object from the `details`
   parameter to avoid leaking internal stack traces to clients.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Security fix

## How Has This Been Tested?

- Tested locally with Firebase emulator (`firebase emulators:start --import=testdata`)
- Verified unauthenticated calls are rejected with `UNAUTHENTICATED`
- Verified authenticated calls with valid unverified email succeed
- Verified already-verified emails return `ABORTED` (not `INVALID_ARGUMENT`)
- Verified nonexistent emails return `INTERNAL` (not leaking details)

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [x] My code follows the code style of this project
- [x] I have run the linter (`npm run lint`)
- [x] I have added/updated tests (if applicable)
- [x] My changes generate no new warnings