### PR TITLE
fix: resolve memory leak in TutorialLikesDislikes component

### DIFF
--- a/src/components/ui-helpers/TutorialLikesDislikes.jsx
+++ b/src/components/ui-helpers/TutorialLikesDislikes.jsx
@@ -10,6 +10,10 @@ const TutorialLikesDislikes = ({ tutorial_id }) => {
   const db = firebase.firestore();
 
   useEffect(() => {
+    let unmounted = false;
+    let unsubscribeLikes = null;
+    let unsubscribeDislikes = null;
+
     const userId = firebase.auth().currentUser?.uid;
 
     if (!userId) {
@@ -26,12 +30,14 @@ const TutorialLikesDislikes = ({ tutorial_id }) => {
     const fetchData = async () => {
       try {
         const tutorialDoc = await tutorialDocRef.get();
+        if (unmounted) return;
         if (!tutorialDoc.exists) {
           throw new Error("Tutorial not found");
         }
 
         // Fetch existing choice of user (if any)
         const userChoiceDoc = await userChoiceRef.get();
+        if (unmounted) return;
         if (userChoiceDoc.exists) {
           const existingChoice = userChoiceDoc.data().value;
           setUserChoice(existingChoice === 1 ? "like" : "dislike");
@@ -40,35 +46,47 @@ const TutorialLikesDislikes = ({ tutorial_id }) => {
         }
 
         // Subscribe to real-time updates for likes and dislikes
-        const unsubscribeLikes = db
+        const likesSnapshotUnsubscribe = db
           .collection("tutorial_likes")
           .where("tut_id", "==", tutorial_id)
           .where("value", "==", 1)
-          .onSnapshot(snapshot => {
+          .onSnapshot((snapshot) => {
+            if (unmounted) return;
             setUpVotes(snapshot.size);
             tutorialDocRef.update({ upVotes: snapshot.size });
           });
 
-        const unsubscribeDislikes = db
+        const dislikesSnapshotUnsubscribe = db
           .collection("tutorial_likes")
           .where("tut_id", "==", tutorial_id)
           .where("value", "==", -1)
-          .onSnapshot(snapshot => {
+          .onSnapshot((snapshot) => {
+            if (unmounted) return;
             setDownVotes(snapshot.size);
             tutorialDocRef.update({ downVotes: snapshot.size });
           });
 
-        // Cleanup function to unsubscribe from listeners when component unmounts
-        return () => {
-          unsubscribeLikes();
-          unsubscribeDislikes();
-        };
+        unsubscribeLikes = likesSnapshotUnsubscribe;
+        unsubscribeDislikes = dislikesSnapshotUnsubscribe;
+
+        if (unmounted) {
+          likesSnapshotUnsubscribe();
+          dislikesSnapshotUnsubscribe();
+        }
       } catch (error) {
-        console.error("Error fetching tutorial data:", error);
+        if (!unmounted) {
+          console.error("Error fetching tutorial data:", error);
+        }
       }
     };
 
     fetchData();
+
+    return () => {
+      unmounted = true;
+      if (unsubscribeLikes) unsubscribeLikes();
+      if (unsubscribeDislikes) unsubscribeDislikes();
+    };
   }, [tutorial_id, db]);
 
   const handleUserChoice = async (event, newChoice) => {


### PR DESCRIPTION
## Description
Refactored the `TutorialLikesDislikes` component to properly manage Firestore real-time listeners. Previously, `onSnapshot` listeners were created in the `useEffect` hook but were never unsubscribed, leading to potential memory leaks when the component unmounted. 

Key changes:
- Created local variables to hold the `unsubscribe` functions returned by both the likes and dislikes Firestore listeners.
- Implemented a `useEffect` cleanup function that calls these `unsubscribe` functions, ensuring no listeners remain active once the component is removed from the DOM.
- Added a `unmounted` flag (using a simple let variable within the effect) and checked it within the asynchronous `fetchData` function and inside the snapshot callbacks. This prevents state updates on can unmounted component, which would otherwise trigger React warnings and waste resources.

## Related Issue
Refers to issue #322

## Motivation and Context
This change is required to ensure efficient resource management. Without this fix, navigating between tutorials could lead to numerous lingering Firestore listeners, increasing memory usage and potentially causing errors in the application state. This follows React's best practices for managing side effects.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] No breaking changes introduced.
