### PR TITLE
feat: implement organization password update functionality 

### DIFF
--- a/src/components/Organization/pages/Passwords.jsx
+++ b/src/components/Organization/pages/Passwords.jsx
@@ -1,6 +1,7 @@
-import React from "react";
-import { Grid, Typography, InputBase, Button } from "@mui/material";
+import React, { useState } from "react";
+import { Grid, Typography, InputBase, Button, Snackbar, Alert, CircularProgress } from "@mui/material";
 import { makeStyles } from "@mui/styles";
+import firebase from "../../../config/index";
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -12,6 +13,7 @@ const useStyles = makeStyles(theme => ({
     justifyContent: "space-evenly",
     width: "98%",
     marginBottom: "20px",
+    padding: "20px",
     [theme.breakpoints.between("xs", "sm")]: {
       marginLeft: "10px"
     }
@@ -36,7 +38,9 @@ const useStyles = makeStyles(theme => ({
   button: {
     border: "1px solid #ccc",
     borderRadius: "10px",
-    padding: "10px"
+    padding: "10px",
+    marginTop: "10px",
+    minWidth: "150px"
   },
   heading: {
     fontSize: "1.5rem",
@@ -54,6 +58,79 @@ const useStyles = makeStyles(theme => ({
 
 function Passwords() {
   const classes = useStyles();
+  const [oldPassword, setOldPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [snackbar, setSnackbar] = useState({
+    open: false,
+    message: "",
+    severity: "success"
+  });
+
+  const handleCloseSnackbar = () => {
+    setSnackbar({ ...snackbar, open: false });
+  };
+
+  const handleUpdatePassword = async () => {
+    if (!oldPassword || !newPassword || !confirmPassword) {
+      setSnackbar({
+        open: true,
+        message: "Please fill in all fields",
+        severity: "error"
+      });
+      return;
+    }
+
+    if (newPassword !== confirmPassword) {
+      setSnackbar({
+        open: true,
+        message: "New passwords do not match",
+        severity: "error"
+      });
+      return;
+    }
+
+    if (newPassword.length < 6) {
+      setSnackbar({
+        open: true,
+        message: "Password should be at least 6 characters",
+        severity: "error"
+      });
+      return;
+    }
+
+    setLoading(true);
+    const user = firebase.auth().currentUser;
+
+    try {
+      // Re-authenticate user before updating password
+      const credential = firebase.auth.EmailAuthProvider.credential(
+        user.email,
+        oldPassword
+      );
+
+      await user.reauthenticateWithCredential(credential);
+      await user.updatePassword(newPassword);
+
+      setSnackbar({
+        open: true,
+        message: "Password updated successfully!",
+        severity: "success"
+      });
+      setOldPassword("");
+      setNewPassword("");
+      setConfirmPassword("");
+    } catch (error) {
+      setSnackbar({
+        open: true,
+        message: error.message,
+        severity: "error"
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
 
   return (
     <React.Fragment>
@@ -69,23 +146,62 @@ function Passwords() {
         </Grid>
         <Grid className={classes.inputContainer} item xs={12}>
           <Typography>Old Password</Typography>
-          <InputBase className={classes.input} placeholder="Old Password" />
+          <InputBase
+            name="oldPassword"
+            type="password"
+            value={oldPassword}
+            onChange={e => setOldPassword(e.target.value)}
+            className={classes.input}
+            placeholder="Old Password"
+          />
         </Grid>
         <Grid className={classes.inputContainer} item xs={12}>
           <Typography>New Password</Typography>
-          <InputBase className={classes.input} placeholder="New Password" />
+          <InputBase
+            name="newPassword"
+            type="password"
+            value={newPassword}
+            onChange={e => setNewPassword(e.target.value)}
+            className={classes.input}
+            placeholder="New Password"
+          />
         </Grid>
         <Grid className={classes.inputContainer} item xs={12}>
           <Typography>Confirm new password</Typography>
           <InputBase
+            name="confirmPassword"
+            type="password"
+            value={confirmPassword}
+            onChange={e => setConfirmPassword(e.target.value)}
             className={classes.input}
             placeholder="Confirm new password"
           />
         </Grid>
         <Grid className={classes.inputContainer} item xs={12}>
-          <Button className={classes.button}>Update Password</Button>
+          <Button
+            className={classes.button}
+            onClick={handleUpdatePassword}
+            disabled={loading}
+          >
+            {loading ? <CircularProgress size={24} /> : "Update Password"}
+          </Button>
         </Grid>
       </Grid>
+
+      <Snackbar
+        open={snackbar.open}
+        autoHideDuration={6000}
+        onClose={handleCloseSnackbar}
+        anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+      >
+        <Alert
+          onClose={handleCloseSnackbar}
+          severity={snackbar.severity}
+          sx={{ width: "100%" }}
+        >
+          {snackbar.message}
+        </Alert>
+      </Snackbar>
     </React.Fragment>
   );
 }


### PR DESCRIPTION
## Description
Transformed the static "Passwords" page in the Organization settings into a fully functional feature. Previously, the page provided the UI shell but lacked the logic to handle password changes.

Technical Implementation:
- Added `useState` for managing input fields: `oldPassword`, `newPassword`, and `confirmPassword`.
- Implemented client-side validation, ensuring all fields are filled, new passwords match, and meet the minimum character requirement (6 characters for Firebase Auth).
- Integrated the Firebase `reauthenticateWithCredential` logic, which is a security requirement for password updates in Firebase.
- Used `user.updatePassword` to securely persist the changes in the authentication backend.
- Added a `Snackbar` with a Material-UI `Alert` to provide success and error notifications, and a `CircularProgress` indicator to give visual feedback during the update process.

## Related Issue
Refers to issue #317

## Motivation and Context
This update completes the security settings for organizations. It solves the issue where users were presented with a non-functional form, ensuring that organizations can manage their account security directly from the dashboard.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] Functional testing performed locally using Firebase Auth.
