### PR TITLE
fix: resolve infinite re-render loop and duplicate React keys (#363)

### DIFF
--- a/src/components/Card/CardWithPicture.jsx
+++ b/src/components/Card/CardWithPicture.jsx
@@ -157,14 +157,18 @@ export default function CardWithPicture({ tutorial }) {
         </CardContent>
       </Link>
       <CardActions className={classes.settings} disableSpacing>
-        <Chip
-          label="HTML"
-          component="a"
-          href="#chip"
-          clickable
-          variant="outlined"
-          className={classes.margin}
-        />
+        {tutorial?.tut_tags &&
+          tutorial?.tut_tags.map((tag, index) => (
+            <Chip
+              label={tag}
+              key={`${tag}-${index}`}
+              component="a"
+              href="#chip"
+              clickable
+              variant="outlined"
+              className={classes.margin}
+            />
+          ))}
         <Typography
           variant="overline"
           display="block"

--- a/src/components/Card/CardWithoutPicture.jsx
+++ b/src/components/Card/CardWithoutPicture.jsx
@@ -146,18 +146,18 @@ export default function CardWithoutPicture({ tutorial }) {
         </CardContent>
       </Link>
       <CardActions className={classes.settings} disableSpacing>
-        {tutorial?.tut_tags &&
-          tutorial?.tut_tags.map((tag, index) => (
-            <Chip
-              label={tag}
-              key={index}
-              component="a"
-              href="#chip"
-              clickable
-              variant="outlined"
-              className={classes.margin}
-            />
-          ))}
+      {tutorial?.tut_tags &&
+        tutorial?.tut_tags.map((tag, index) => (
+          <Chip
+            label={tag}
+            key={`${tag}-${index}`}
+            component="a"
+            href="#chip"
+            clickable
+            variant="outlined"
+            className={classes.margin}
+          />
+        ))}
         <Typography
           variant="overline"
           display="block"

--- a/src/components/CardTabs/Events/index.jsx
+++ b/src/components/CardTabs/Events/index.jsx
@@ -50,7 +50,7 @@ const EventsCard = props => {
           {props.events.map(function (event, index) {
             return (
               <Grid
-                key={index}
+                key={event.name + index}
                 container
                 direction="row"
                 spacing={2}

--- a/src/components/CardTabs/Users/index.jsx
+++ b/src/components/CardTabs/Users/index.jsx
@@ -121,7 +121,7 @@ const UserCard = ({ title, userId }) => {
             usersToFollow.map(function (user, index) {
               return (
                 <UserElement
-                  key={index}
+                  key={user.uid || index}
                   user={user}
                   index={index}
                   useStyles={useStyles}
@@ -133,7 +133,7 @@ const UserCard = ({ title, userId }) => {
             contributors.map(function (user, index) {
               return (
                 <UserElement
-                  key={index}
+                  key={user.name + index}
                   user={user}
                   index={index}
                   useStyles={useStyles}

--- a/src/components/HomePage/index.jsx
+++ b/src/components/HomePage/index.jsx
@@ -125,8 +125,10 @@ function HomePage({ background = "white", textColor = "black" }) {
       );
       getTutorialFeedData(tutorialIdArray)(firebase, firestore, dispatch);
     };
-    getFeed();
-  }, []);
+    if (profileData.uid) {
+      getFeed();
+    }
+  }, [profileData.uid, firebase, firestore, dispatch]);
 
   useEffect(() => {
     setTutorials(tutorialFeedArray);
@@ -231,11 +233,17 @@ function HomePage({ background = "white", textColor = "black" }) {
           <Box item sx={{ display: { md: "none" } }}>
             <TagCard tags={tags} />
           </Box>
-          {tutorials.map(tutorial => {
+          {tutorials.map((tutorial, index) => {
             return !tutorial?.featured_image ? (
-              <CardWithoutPicture tutorial={tutorial} />
+              <CardWithoutPicture
+                tutorial={tutorial}
+                key={tutorial.tutorial_id || index}
+              />
             ) : (
-              <CardWithPicture tutorial={tutorial} />
+              <CardWithPicture
+                tutorial={tutorial}
+                key={tutorial.tutorial_id || index}
+              />
             );
           })}
           <Box


### PR DESCRIPTION
## Summary
- Fixed infinite re-render loop on the HomePage by adding missing dependencies to the `useEffect` hook fetching the tutorial feed.
- Resolved "duplicate key" warnings by ensuring unique React keys in `CardWithPicture`, `CardWithoutPicture`, `UserCard`, and `EventsCard`.
- Corrected `CardWithPicture` to dynamically render tutorial tags instead of a hardcoded "HTML" chip.

Closes #363