### PR TITLE
fix: correct MiniNavbar width breakpoint comparisons

### DIFF
--- a/src/components/NavBar/new/MiniNavbar/index.jsx
+++ b/src/components/NavBar/new/MiniNavbar/index.jsx
@@ -178,8 +178,8 @@ function MiniNavbar() {
                   style={{
                     display: "inline-block",
                     width:
-                      screenSize.dynamicWidth < "959" &&
-                      screenSize.dynamicWidth > "575"
+                      screenSize.dynamicWidth < 959 &&
+                      screenSize.dynamicWidth > 575
                         ? "93.5%"
                         : "88.5%"
                   }}


### PR DESCRIPTION
## Description

This PR fixes MiniNavbar responsive width logic by replacing string-based viewport breakpoint comparisons with numeric comparisons.

## Related Issue

Closes #387

## Motivation and Context

The responsive search input width in MiniNavbar was computed using string literals for breakpoint checks.  
Breakpoint logic should be numeric to avoid inconsistent behavior across screen sizes.

## How Has This Been Tested?

- Verified code change is minimal and isolated to MiniNavbar responsive width condition.
- Manually reviewed breakpoint logic for 575px–959px range behavior.

## Screenshots or GIF (In case of UI changes):

**500px or more :** 
<img width="400" height="600" alt="image" src="https://github.com/user-attachments/assets/bfee065b-cd41-4a6d-ac20-68b81c0ae69e" />
**350-500px:** 
<img width="400" height="600" alt="image" src="https://github.com/user-attachments/assets/b6748ff4-7819-4b42-9218-51727e78e576" />
**300-350px :**
<img width="400" height="600" alt="image" src="https://github.com/user-attachments/assets/d6575d8b-4c6a-404c-aec5-7ec1c472531a" />

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.