### PR TITLE
Bug Report: Broken/Dead Link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Contributions are always welcome!
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for ways to get started.
 
-Please adhere to this project's [code of conduct](./code_of_conduct.md).
+Please adhere to this project's [code of conduct](./CODE_OF_CONDUCT.md).
 
 # FAQs
 


### PR DESCRIPTION
Updated the Code of Conduct URL in the README. The previous link was outdated, so it was replaced with the correct location.

Related Issue
Fixes Broken Link in README
Fixes #390

Motivation and Context
The README needed an updated Code of Conduct link so contributors can find the correct policy page without confusion.

How Has This Been Tested?
Verified that the README renders correctly on GitHub and that the updated link points to the intended page.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
