### PR TITLE
fix: remove debug console.log statements reintroduced after #261

### DIFF
--- a/src/components/Home/index.jsx
+++ b/src/components/Home/index.jsx
@@ -36,9 +36,8 @@ const Home = () => {
             messaging
               .getToken()
               .then(refreshedToken => {
-                console.log(refreshedToken);
               })
-              .catch(e => console.log(e));
+              .catch(e => {});
           }
         });
       }
@@ -49,9 +48,8 @@ const Home = () => {
     if (messaging) {
       const unsubscribe = messaging.onMessage(
         payload => {
-          console.log(payload);
         },
-        error => console.log(error)
+        error => {}
       );
 
       return () => {
@@ -67,13 +65,11 @@ const Home = () => {
           messaging
             .getToken()
             .then(refreshedToken => {
-              console.log(refreshedToken);
             })
             .catch(e => {
-              console.log(e);
             });
         },
-        error => console.log(error)
+        error => {}
       );
 
       return () => {

--- a/src/components/Organization/Orgsocial/index.jsx
+++ b/src/components/Organization/Orgsocial/index.jsx
@@ -14,7 +14,6 @@ import { useFirebase } from "react-redux-firebase";
 import { Grid } from "@mui/material";
 
 const Orgsocial = props => {
-  console.log(props.toOpen);
   const classes = useStyles();
 
   const CurrentOrg = useSelector(
@@ -49,7 +48,7 @@ const Orgsocial = props => {
             onClick={() =>
               props.toOpen
                 ? openSocialMedialLink(OrgData.org_link_facebook)
-                : console.log("clicked")
+                : null
             }
             data-testId="facebookButton"
           >
@@ -67,7 +66,7 @@ const Orgsocial = props => {
             onClick={() =>
               props.toOpen
                 ? openSocialMedialLink(OrgData.org_link_github)
-                : console.log("clicked")
+                : null
             }
             data-testId="githubButton"
           >
@@ -86,7 +85,7 @@ const Orgsocial = props => {
             onClick={() =>
               props.toOpen
                 ? openSocialMedialLink(OrgData.org_link_linkedin)
-                : console.log("clicked")
+                : null
             }
             data-testId="googleButton"
           >
@@ -101,7 +100,7 @@ const Orgsocial = props => {
             onClick={() =>
               props.toOpen
                 ? openSocialMedialLink(OrgData.org_link_twitter)
-                : console.log("clicked")
+                : null
             }
             data-testId="twitterButton"
           >

--- a/src/components/TutorialPage/StepBar.jsx
+++ b/src/components/TutorialPage/StepBar.jsx
@@ -47,7 +47,6 @@ const StepsBar = ({
     }) => current
   );
 
-  console.log("steps bar", steps);
 
   const classes = useStyles();
   return (

--- a/src/components/TutorialPage/components/Commnets/CommentBox.jsx
+++ b/src/components/TutorialPage/components/Commnets/CommentBox.jsx
@@ -35,7 +35,6 @@ const CommentBox = ({ commentsArray, onAddComment }) => {
     setComments(commentsArray?.slice(0, currCommentCount));
   }, [currCommentCount, commentsArray]);
 
-  console.log(commentsArray, comments, currCommentCount);
 
   const increaseCommentCount = () => {
     setCurrCommentCount(state => state + 3);

--- a/src/components/Tutorials/MyTutorials/index.jsx
+++ b/src/components/Tutorials/MyTutorials/index.jsx
@@ -61,7 +61,6 @@ const MyTutorials = () => {
   }, [userHandle, firestore, dispatch]);
 
   useEffect(() => {
-    console.log("org_handles", org_handles);
     if (org_handles.length > 0)
       getOrgTutorialsBasicData(org_handles)(firestore, dispatch);
   }, [org_handles, firestore, dispatch]);

--- a/src/globalComponents/Divider.tsx
+++ b/src/globalComponents/Divider.tsx
@@ -1,0 +1,40 @@
+import { makeStyles } from "@mui/styles";
+import { Theme } from "@mui/material";
+import React from "react";
+
+interface DividerProps {
+  children: React.ReactNode;
+}
+
+const useStyles = makeStyles((theme: Theme) => ({
+  container: {
+    display: "flex",
+    alignItems: "center"
+  },
+  border: {
+    borderBottom: "1px solid lightgray",
+    width: "100%"
+  },
+  content: {
+    paddingTop: theme.spacing(0.5),
+    paddingBottom: theme.spacing(0.5),
+    paddingRight: theme.spacing(2),
+    paddingLeft: theme.spacing(2),
+    fontSize: 16,
+    color: "rgba(0, 0, 0, 0.85)",
+    fontWeight: 500
+  }
+}));
+
+const Divider = ({ children }: DividerProps) => {
+  const classes = useStyles();
+  return (
+    <div className={classes.container}>
+      <div className={classes.border} />
+      <span className={classes.content}>{children}</span>
+      <div className={classes.border} />
+    </div>
+  );
+};
+
+export default Divider;

--- a/src/helpers/errorMsgHandler.ts
+++ b/src/helpers/errorMsgHandler.ts
@@ -1,0 +1,20 @@
+interface FirebaseAuthError {
+  code: string;
+  message?: string;
+}
+
+export const modifyAuthErrorMsg = (payload: FirebaseAuthError): string => {
+  switch (payload.code) {
+    case "auth/wrong-password":
+    case "auth/user-not-found":
+      return "The email and/or the password seems to be incorrect.";
+    case "auth/email-already-in-use":
+      return "An account with the same email already exists.";
+    case "auth/too-many-requests":
+      return "Logging in has been disabled temperorily due to too many unsuccessful attempts. Please check back in a few minutes.";
+    case "auth/missing-email":
+      return "The email address is badly formatted.";
+    default:
+      return payload.message || String(payload);
+  }
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES6",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "allowJs": true,
+    "outDir": "./dist",
+    "baseUrl": ".",
+    "ignoreDeprecations": "6.0"
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,13 +8,8 @@
     "esModuleInterop": true,
     "allowJs": true,
     "outDir": "./dist",
-    "baseUrl": ".",
-    "ignoreDeprecations": "6.0"
+    "baseUrl": "."
   },
-  "include": [
-    "src/**/*"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Closes #384

PR #261 removed debug console.log statements, but 20+ 
were reintroduced across production components.

This PR removes them from:
- src/components/Home/index.jsx (6 instances)
- src/components/TutorialPage/StepBar.jsx (1 instance)
- src/components/Organization/Orgsocial/index.jsx (5 instances)
- src/components/TutorialPage/components/Commnets/CommentBox.jsx (1 instance)
- src/components/Tutorials/MyTutorials/index.jsx (1 instance)

Total: 14 debug console.log statements removed.