### PR TITLE
fix: populate create tutorial owner options

### DIFF
--- a/src/components/Tutorials/NewTutorial/index.jsx
+++ b/src/components/Tutorials/NewTutorial/index.jsx
@@ -127,6 +127,8 @@ const NewTutorial = ({ viewModal, onSidebarClick, viewCallback, active }) => {
     }) => displayName
   );
 
+  const firebaseUser = firebase.auth().currentUser;
+
   //This name should be replaced by displayName when implementing backend
   const sampleName = "User Name Here";
   const allowOrgs = organizations && organizations.length > 0;
@@ -144,17 +146,28 @@ const NewTutorial = ({ viewModal, onSidebarClick, viewCallback, active }) => {
           .filter(Boolean)
       : null;
 
+  const ownerOptions = [
+    {
+      value: userHandle || firebaseUser?.uid || firebaseUser?.email || "me",
+      label: displayName || firebaseUser?.displayName || "Personal tutorial"
+    },
+    ...(orgList || []).map(org => ({
+      value: org.org_handle,
+      label: org.org_name
+    }))
+  ];
+
   useEffect(() => {
     setTags([]);
     setNewTag("");
     setformValue({
       title: "",
       summary: "",
-      owner: "",
+      owner: userHandle || firebaseUser?.uid || firebaseUser?.email || "me",
       tags: []
     });
     setVisible(viewModal);
-  }, [viewModal]);
+  }, [viewModal, userHandle, firebaseUser]);
 
   const onSubmit = formData => {
     formData.preventDefault();
@@ -240,10 +253,10 @@ const NewTutorial = ({ viewModal, onSidebarClick, viewCallback, active }) => {
         >
           <Typography>
             <Select
-              options={organizations?.map(org => ({
-                value: org.org_handle,
-                label: org.org_name
-              }))}
+              options={ownerOptions}
+              value={ownerOptions.find(
+                option => option.value === formValue.owner
+              )}
               onChange={data => {
                 onOwnerChange(data.value);
               }}


### PR DESCRIPTION
## Description

This PR fixes the Create Tutorial modal so the owner Select always has valid options.

## Related Issue

Closes #395 

## Motivation and Context

The Create Tutorial flow was rendering an empty dropdown with "No options", which prevented users from selecting an owner for a new tutorial. The modal now provides a personal owner fallback and also includes eligible organization options.

## How Has This Been Tested?

- Opened the Create Tutorial modal locally.
- Verified the owner Select now includes a personal owner option.
- Verified organization options are included when available.
- Restarted the app container to confirm the updated modal renders correctly.

## Screenshots or GIF (In case of UI changes):

### **Before :** 

<img width="955" height="464" alt="d" src="https://github.com/user-attachments/assets/0b99b084-2ff2-4ab1-8806-4c69267ac5f9" />

### **After:**  

<img width="959" height="474" alt="e" src="https://github.com/user-attachments/assets/253e22b1-abc2-49f0-b999-9bd18bfa5f35" />

<img width="1919" height="843" alt="image" src="https://github.com/user-attachments/assets/20e4f029-f384-4142-8382-d8d68d3eebd7" />

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.