### PR TITLE
refactor(helpers): migrate TutorialTimeRemaining to TypeScript

### DIFF
--- a/src/helpers/tutorialTime.ts
+++ b/src/helpers/tutorialTime.ts
@@ -1,0 +1,25 @@
+/**
+ * Represents a single tutorial step.
+ * Extend this interface if your step objects have additional fields.
+ */
+export interface Step {
+  time: string | number;
+}
+
+/**
+ * Calculates total time remaining from the current step to the end.
+ *
+ * @param steps       - Full array of tutorial steps
+ * @param currentStep - Zero-based index of the active step
+ * @returns           Total minutes remaining (including the current step)
+ */
+export const TutorialTimeRemaining = (
+  steps: Step[],
+  currentStep: number
+): number => {
+  const remainingSteps = steps.slice(currentStep); // slice, not splice — avoids mutating original array
+  return remainingSteps.reduce(
+    (total, step) => total + parseInt(String(step.time), 10),
+    0
+  );
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES6",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "allowJs": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Description

This pull request migrates the `TutorialTimeRemaining` helper from JavaScript to TypeScript, improving type safety and code reliability.

## Changes

* Renamed `tutorialTime.js` to `tutorialTime.ts`
* Introduced a `Step` interface to define the structure of step objects
* Replaced `.splice()` with `.slice()` to prevent unintended mutation of the input array
* Refactored iteration logic to use `.reduce()` for improved clarity and functional style
* Added JSDoc comments for better documentation and maintainability

## Related Issue

N/A

## Motivation and Context

This change enhances type safety and eliminates potential side effects caused by mutating the original steps array. It also aligns the helper with the project's TypeScript migration efforts and improves overall code readability.

## How Has This Been Tested?

* Performed static type checking using `npx tsc --noEmit`
* Verified that the refactored implementation produces the same output as the previous version

## Screenshots or GIF (In case of UI changes):

N/A

## Types of changes

* [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

* [x] My code follows the code style of this project.
* [ ] My change requires a change to the documentation.
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [ ] All new and existing tests passed.
