### PR TITLE
Feat/UI improvement mini navbar

### DIFF
--- a/src/components/NavBar/new/MiniNavbar/index.jsx
+++ b/src/components/NavBar/new/MiniNavbar/index.jsx
@@ -6,8 +6,8 @@ import {
   InputBase,
   Paper
 } from "@mui/material";
-import { makeStyles } from "@mui/styles";
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import { styled } from "@mui/material/styles";
+import React, { useCallback, useState } from "react";
 import { useLocation } from "react-router-dom";
 import Headroom from "react-headroom";
 import BrandName from "../../../../helpers/brandName";
@@ -21,93 +21,86 @@ import { useSelector } from "react-redux";
 import { useDispatch } from "react-redux";
 import { searchFromTutorialsIndex } from "../../../../store/actions";
 
-const useStyles = makeStyles(theme => ({
-  input: {
-    marginLeft: theme.spacing(1),
-    flex: 1,
-    color: "#3e5060",
-    letterSpacing: "0.5px"
-  },
-  root: {
-    backgroundColor: theme.palette.grey[50],
-    padding: "2px",
-    border: "1px solid #ced4da",
-    borderRadius: "0.8rem",
-    width: "100%"
-  },
-  icon: {
-    padding: "2px",
-    color: theme.palette.primary.main
-  },
-  grid: {
-    "& > *": {
-      margin: theme.spacing(1)
-    },
-    [theme.breakpoints.down("md")]: {
-      display: "none"
-    }
-  },
-  gridButton: {
-    "& > *": {
-      margin: theme.spacing(1)
-    },
-    [theme.breakpoints.down("sm")]: {
-      display: "none"
-    }
-  },
-  button: {
-    borderRadius: "10px"
-  },
-  hamburger: {
-    [theme.breakpoints.up("md")]: {
-      display: "none"
-    }
+// ── Styled components (replaces deprecated makeStyles) ──────────
+const SearchPaper = styled(Paper)(({ theme }) => ({
+  backgroundColor: theme.palette.grey[50],
+  padding: "2px",
+  border: "1px solid #ced4da",
+  borderRadius: "0.8rem",
+  width: "100%",
+  display: "flex",
+  alignItems: "center"
+}));
+
+const SearchInput = styled(InputBase)(({ theme }) => ({
+  marginLeft: theme.spacing(1),
+  flex: 1,
+  color: "#3e5060",
+  letterSpacing: "0.5px"
+}));
+
+const SearchIconButton = styled(IconButton)(({ theme }) => ({
+  padding: "2px",
+  color: theme.palette.primary.main
+}));
+
+const NavButton = styled(Button)(() => ({
+  borderRadius: "10px"
+}));
+
+const HamburgerBox = styled("div")(({ theme }) => ({
+  display: "flex",
+  [theme.breakpoints.up("md")]: {
+    display: "none"
   }
 }));
 
-function MiniNavbar() {
-  const classes = useStyles();
+const ButtonBox = styled("div")(({ theme }) => ({
+  display: "flex",
+  gap: theme.spacing(1),
+  [theme.breakpoints.down("sm")]: {
+    display: "none"
+  }
+}));
 
+// ────────────────────────────────────────────────────────────────
+
+function MiniNavbar() {
   const history = useHistory();
   const dispatch = useDispatch();
+
   const notifications = useSelector(
     state => state.notifications.data.notifications
   );
   const notificationCount = notifications?.filter(
     notification => !notification.isRead
   ).length;
-  const [openDrawer, setOpenDrawer] = React.useState(false);
+
+  const [openDrawer, setOpenDrawer] = useState(false);
   const [openMenu, setOpen] = useState(false);
-  const toggleSlider = () => {
-    setOpen(!openMenu);
-  };
 
+  // Single source of truth for window size — no duplicate resize logic
   const windowSize = useWindowSize();
+  const isMobile = (windowSize.width ?? 0) <= 960;
 
-  const location = useLocation();
-  const routeName = location.pathname;
-
-  const excludedRoutes = ["/login", "/signup"];
+  const toggleSlider = useCallback(() => {
+    setOpen(prev => !prev);
+  }, []);
 
   const toggleDrawer = useCallback(state => {
     setOpenDrawer(state);
   }, []);
 
-  const [screenSize, getDimension] = useState({
-    dynamicWidth: window.innerWidth,
-    dynamicHeight: window.innerHeight
-  });
-  const setDimension = () => {
-    getDimension({
-      dynamicWidth: window.innerWidth,
-      dynamicHeight: window.innerHeight
-    });
-  };
+  const location = useLocation();
+  const routeName = location.pathname;
+  const excludedRoutes = ["/login", "/signup"];
 
   const [searchQuery, setSearchQuery] = useState("");
+
   const handleSearchChange = e => {
     setSearchQuery(e.target.value);
   };
+
   const handleSearch = () => {
     if (searchQuery.length > 0) {
       dispatch(searchFromTutorialsIndex(searchQuery));
@@ -115,224 +108,171 @@ function MiniNavbar() {
     }
   };
 
-  useEffect(() => {
-    window.addEventListener("resize", setDimension);
-
-    return () => {
-      window.removeEventListener("resize", setDimension);
-    };
-  }, [screenSize]);
+  const handleKeyDown = e => {
+    if (e.key === "Enter") {
+      handleSearch();
+    }
+  };
 
   return (
     <Headroom disableInlineStyles>
-      <nav
-        style={{
-          padding: "10px",
-          background: "white"
-        }}
-      >
+      <nav style={{ padding: "10px", background: "white" }}>
         <Grid
           container
           direction="row"
           justifyContent="space-between"
           alignItems="center"
+          spacing={1}
         >
+          {/* Brand + Hamburger */}
           <Grid item xs={12} md={3} container alignItems="center">
             <Grid
               item
-              style={{
-                flexGrow: 1
-              }}
-              onClick={() => {
-                history.push("/");
-              }}
+              style={{ flexGrow: 1, cursor: "pointer" }}
+              onClick={() => history.push("/")}
               data-testid="navbarBrand"
             >
               <BrandName />
             </Grid>
-            <Grid item className={classes.hamburger}>
-              <IconButton>
-                {window.innerWidth > 960 && (
-                  <MenuIcon onClick={() => toggleDrawer(true)} />
-                )}
-                {window.innerWidth <= 960 && (
-                  <MenuIcon onClick={() => toggleSlider()} />
-                )}
+            <HamburgerBox>
+              <IconButton
+                aria-label="open navigation menu"
+                onClick={isMobile ? toggleSlider : () => toggleDrawer(true)}
+              >
+                <MenuIcon />
               </IconButton>
-            </Grid>
+            </HamburgerBox>
           </Grid>
+
+          {/* Search Bar */}
           {!excludedRoutes.includes(routeName) && (
-            <Grid style={{ display: "inline-block" }} item xs={12} md={4}>
-              <Paper component={"form"} className={classes.root} elevation={0}>
-                <IconButton
+            <Grid item xs={12} md={4}>
+              <SearchPaper component="form" elevation={0}>
+                <SearchIconButton
                   type="button"
                   aria-label="search"
                   disableRipple
-                  className={classes.icon}
                   data-testid="navbarSearch"
                   onClick={handleSearch}
                 >
                   <SearchIcon />
-                </IconButton>
-                <InputBase
-                  style={{
-                    display: "inline-block",
-                    width:
-                      screenSize.dynamicWidth < "959" &&
-                      screenSize.dynamicWidth > "575"
-                        ? "93.5%"
-                        : "88.5%"
-                  }}
-                  className={classes.input}
+                </SearchIconButton>
+                <SearchInput
                   placeholder="Search..."
                   value={searchQuery}
                   onChange={handleSearchChange}
+                  onKeyDown={handleKeyDown}
+                  inputProps={{ "aria-label": "search tutorials" }}
                 />
-              </Paper>
+              </SearchPaper>
             </Grid>
           )}
-          <Grid item className={classes.gridButton}>
-            <Button
-              variant="contained"
-              color="primary"
-              style={{
-                boxShadow: "none",
-                color: "white"
-              }}
-              data-test-id="login"
-              className={classes.button}
-              onClick={() => history.push("/login")}
-            >
-              Login
-            </Button>
-            <Button
-              variant="outlined"
-              color="primary"
-              style={{
-                boxShadow: "none"
-              }}
-              className={classes.button}
-              onClick={() => history.push("/signup")}
-            >
-              Sign Up
-            </Button>
+
+          {/* Login / Sign Up buttons */}
+          <Grid item>
+            <ButtonBox>
+              <NavButton
+                variant="contained"
+                color="primary"
+                style={{ boxShadow: "none", color: "white" }}
+                data-test-id="login"
+                onClick={() => history.push("/login")}
+              >
+                Login
+              </NavButton>
+              <NavButton
+                variant="outlined"
+                color="primary"
+                style={{ boxShadow: "none" }}
+                onClick={() => history.push("/signup")}
+              >
+                Sign Up
+              </NavButton>
+            </ButtonBox>
           </Grid>
         </Grid>
       </nav>
-      {windowSize.width > 960 && (
-        <Drawer anchor="right" open={openDrawer} onClose={() => toggleDrawer()}>
+
+      {/* Desktop Drawer */}
+      {!isMobile && (
+        <Drawer
+          anchor="right"
+          open={openDrawer}
+          onClose={() => toggleDrawer(false)}
+        >
           <Grid
             container
-            style={{
-              width: 200
-            }}
+            style={{ width: 200 }}
             direction="column"
           >
             <Grid item>
-              <IconButton>
+              <IconButton aria-label="close drawer">
                 <CloseIcon onClick={() => toggleDrawer(false)} />
               </IconButton>
             </Grid>
-
-            <Grid
-              item
-              style={{
-                padding: 10
-              }}
-            >
-              <Button
+            <Grid item style={{ padding: 10 }}>
+              <NavButton
                 variant="contained"
                 color="primary"
-                style={{
-                  boxShadow: "none",
-                  color: "white"
-                }}
-                className={classes.button}
+                style={{ boxShadow: "none", color: "white" }}
                 onClick={() => {
                   toggleDrawer(false);
                   history.push("/login");
                 }}
               >
                 Login
-              </Button>
+              </NavButton>
             </Grid>
-            <Grid
-              item
-              style={{
-                padding: 10
-              }}
-            >
-              <Button
+            <Grid item style={{ padding: 10 }}>
+              <NavButton
                 variant="outlined"
                 color="primary"
-                style={{
-                  boxShadow: "none"
-                }}
-                className={classes.button}
+                style={{ boxShadow: "none" }}
                 onClick={() => {
                   toggleDrawer(false);
                   history.push("/signup");
                 }}
               >
                 Sign Up
-              </Button>
+              </NavButton>
             </Grid>
           </Grid>
         </Drawer>
       )}
-      {windowSize.width <= 960 && (
+
+      {/* Mobile Sidebar */}
+      {isMobile && (
         <SideBar
           open={openMenu}
           toggleSlider={toggleSlider}
           notificationCount={notificationCount}
         >
-          {window.innerWidth <= 960 && (
-            <>
-              <Grid
-                item
-                style={{
-                  padding: 10
-                }}
-              >
-                <Button
-                  variant="contained"
-                  color="primary"
-                  style={{
-                    boxShadow: "none",
-                    color: "white"
-                  }}
-                  className={classes.button}
-                  onClick={() => {
-                    toggleSlider();
-                    history.push("/login");
-                  }}
-                >
-                  Login
-                </Button>
-              </Grid>
-              <Grid
-                item
-                style={{
-                  padding: 10
-                }}
-              >
-                <Button
-                  variant="outlined"
-                  color="primary"
-                  style={{
-                    boxShadow: "none"
-                  }}
-                  className={classes.button}
-                  onClick={() => {
-                    toggleSlider();
-                    history.push("/signup");
-                  }}
-                >
-                  Sign Up
-                </Button>
-              </Grid>
-            </>
-          )}
+          <Grid item style={{ padding: 10 }}>
+            <NavButton
+              variant="contained"
+              color="primary"
+              style={{ boxShadow: "none", color: "white" }}
+              onClick={() => {
+                toggleSlider();
+                history.push("/login");
+              }}
+            >
+              Login
+            </NavButton>
+          </Grid>
+          <Grid item style={{ padding: 10 }}>
+            <NavButton
+              variant="outlined"
+              color="primary"
+              style={{ boxShadow: "none" }}
+              onClick={() => {
+                toggleSlider();
+                history.push("/signup");
+              }}
+            >
+              Sign Up
+            </NavButton>
+          </Grid>
         </SideBar>
       )}
     </Headroom>

--- a/src/components/SideBar/index.jsx
+++ b/src/components/SideBar/index.jsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { Drawer } from "@mui/material";
+import { styled } from "@mui/material/styles";
 import SideList from "../SideBar/sidelist";
 import Home from "./../../assets/images/home.svg";
 import Notification from "./../../assets/images/notification.svg";
@@ -13,26 +14,23 @@ import { useSelector } from "react-redux";
 import Tutorials from "./../../assets/images/tutorial.svg";
 import MyFeed from "./../../assets/images/MyFeed.svg";
 import { signOut } from "../../store/actions";
-import { makeStyles } from "@mui/styles";
 import useWindowSize from "../../helpers/customHooks/useWindowSize";
 import { useFirebase } from "react-redux-firebase";
 import { useDispatch } from "react-redux";
 import { useAllowDashboard } from "../../helpers/customHooks";
 import Card from "@mui/material/Card";
 
-const useStyles = makeStyles(theme => ({
-  drawer: {
-    width: 250,
-    flexShrink: 0,
-    display: theme.breakpoints.down("md") ? null : "none"
-  },
-  drawerPaper: {
+const StyledDrawer = styled(Drawer)(() => ({
+  width: 250,
+  flexShrink: 0,
+  "& .MuiDrawer-paper": {
     width: 250
-  },
-  card: {
-    margin: "0.1rem",
-    padding: "0.5rem 1.5rem 0.5rem 0.5rem"
   }
+}));
+
+const StyledCard = styled(Card)(() => ({
+  margin: "0.1rem",
+  padding: "0.5rem 1.5rem 0.5rem 0.5rem"
 }));
 
 const SideBar = ({
@@ -50,7 +48,6 @@ const SideBar = ({
   const dispatch = useDispatch();
   const allowDashboard = useAllowDashboard();
 
-  //Taking out the current organization handle of the user
   const currentOrg = useSelector(
     ({
       org: {
@@ -113,51 +110,45 @@ const SideBar = ({
     }
   ];
 
-  const classes = useStyles();
-  return (
-    <>
-      {windowSize.width <= (drawWidth || 960) ? (
-        <Drawer
-          closable="true"
-          open={open}
-          anchor="right"
-          onClose={toggleSlider}
-          data-testId="sidebar_mobile"
-          style={{ zIndex: 99999 }}
-          classes={{
-            root: classes.drawer,
-            paper: classes.drawerPaper
-          }}
-          xs={12}
-          md={3}
+  if (windowSize.width <= (drawWidth || 960)) {
+    return (
+      <StyledDrawer
+        closable="true"
+        open={open}
+        anchor="right"
+        onClose={toggleSlider}
+        data-testId="sidebar_mobile"
+        style={{ zIndex: 99999 }}
+        xs={12}
+        md={3}
+      >
+        <SideList
+          menuItems={menuItems || defaultMenu}
+          value={value}
+          onStateChange={onStateChange}
+          toggleSlider={toggleSlider}
+          notificationCount={notificationCount}
+          style={{ position: "absolute" }}
         >
-          <SideList
-            menuItems={menuItems || defaultMenu}
-            value={value}
-            onStateChange={onStateChange}
-            toggleSlider={toggleSlider}
-            style={{
-              position: "absolute"
-            }}
-          >
-            {children}
-          </SideList>
-        </Drawer>
-      ) : (
-        <Card className={classes.card}>
-          <div data-testId="sidebar_desktop">
-            <SideList
-              menuItems={menuItems || defaultMenu}
-              value={value}
-              onStateChange={onStateChange}
-              notificationCount={notificationCount}
-            >
-              {children}
-            </SideList>
-          </div>
-        </Card>
-      )}
-    </>
+          {children}
+        </SideList>
+      </StyledDrawer>
+    );
+  }
+
+  return (
+    <StyledCard>
+      <div data-testId="sidebar_desktop">
+        <SideList
+          menuItems={menuItems || defaultMenu}
+          value={value}
+          onStateChange={onStateChange}
+          notificationCount={notificationCount}
+        >
+          {children}
+        </SideList>
+      </div>
+    </StyledCard>
   );
 };
 

--- a/src/components/SideBar/sidelist.jsx
+++ b/src/components/SideBar/sidelist.jsx
@@ -1,73 +1,65 @@
-import React, { useEffect, useState } from "react";
-import { NavLink, useHistory, useLocation } from "react-router-dom";
+import React from "react";
+import { NavLink, useLocation } from "react-router-dom";
 import {
   MenuItem,
   MenuList,
   ListItemIcon,
   ListItemText,
-  Paper,
-  Grid,
-  Button
+  Paper
 } from "@mui/material";
-import { makeStyles } from "@mui/styles";
+import { styled } from "@mui/material/styles";
 import NotificationsIcon from "@mui/icons-material/Notifications";
 import Badge from "@mui/material/Badge";
 
-const useStyles = makeStyles(theme => ({
-  icons: {
-    width: "20px",
-    height: "20px"
-  },
+const StyledPaper = styled(Paper)(() => ({
+  display: "flex",
+  minWidth: "100%",
+  border: "none",
+  backgroundColor: "transparent",
+  boxShadow: "none"
+}));
 
-  listIcon: {
-    minWidth: "20px",
-    marginRight: "10px"
-  },
+const StyledMenuList = styled(MenuList)(() => ({
+  border: "none",
+  boxShadow: "none",
+  width: "100%"
+}));
 
-  paper: {
-    display: "flex",
-    minWidth: "100%",
-    border: "none",
-    backgrounColor: "transparent",
-    boxShadow: "none"
-  },
+const StyledMenuItem = styled(MenuItem)(() => ({
+  width: "100%",
+  height: "100%",
+  borderRadius: "100px",
+  paddingTop: "8px",
+  paddingBottom: "3px",
+  margin: "3px 0 3px 0"
+}));
 
-  navLink: {
-    display: "flex",
-    flexDirection: "row",
-    alignItems: "center"
-  },
+const NavLinkStyled = styled(NavLink)(() => ({
+  display: "flex",
+  flexDirection: "row",
+  alignItems: "center"
+}));
 
-  menuList: {
-    border: "none",
-    boxShadow: "none"
-  },
+const iconStyles = {
+  width: "20px",
+  height: "20px"
+};
 
-  menuItem: {
-    width: "100%",
-    height: "100%",
-    borderRadius: "100px",
-    paddingTop: "8px",
-    paddingBottom: "3px",
-    margin: "3px 0 3px 0"
-  },
+const listIconStyles = {
+  minWidth: "20px",
+  marginRight: "10px"
+};
 
-  notification: {
-    color: "#000000"
-  },
-  customBadge: {
+const customBadgeSx = {
+  "& .MuiBadge-badge": {
     color: "#ffffff",
     backgroundColor: "#03AAFA",
     fontSize: "0.6rem",
     height: "16px",
     minWidth: "16px"
   }
-}));
+};
 
-/**
- * @description - This component renders the side bar menu
- * @returns
- */
 const SideList = ({
   menuItems = [],
   value,
@@ -77,155 +69,136 @@ const SideList = ({
   children,
   notificationCount
 }) => {
-  const classes = useStyles();
   const location = useLocation();
 
-  /**
-   * * Cases for rendering the menu items
-   *
-   * ? 1. item.link - If the item has a link, render a NavLink
-   * ? 2. item.onClick - If the item has an onClick, render a button
-   * ? if the item has neither, render a MenuItem with no onClick
-   *
-   */
   return (
-    <Paper className={classes.paper} style={style}>
-      <MenuList className={classes.menuList}>
+    <StyledPaper style={style}>
+      <StyledMenuList>
         {menuItems.map(function (item, index) {
+          const itemKey = item.link || item.name || index;
+
+          const textStyle = {
+            fontWeight: item?.id && value === item?.id ? "bold" : "normal",
+            color: item?.link === location.pathname ? "#0293d9" : "black"
+          };
+
+          const activeBackground =
+            item.link === location.pathname
+              ? { background: "#d9f1fc", borderRadius: "100px" }
+              : {};
+
           return (
             <div
-              key="menu-items"
-              style={
-                item.link == location.pathname
-                  ? { background: "#d9f1fc", borderRadius: "100px" }
-                  : {}
-              }
+              key={itemKey}
+              style={activeBackground}
               data-testId={item?.dataTestId}
             >
               {item.link && (
-                <NavLink to={item.link} className={classes.navLink}>
-                  <MenuItem
-                    key={item.link}
+                <NavLinkStyled to={item.link}>
+                  <StyledMenuItem
                     onClick={() => {
                       toggleSlider();
                       onStateChange(index);
                     }}
-                    className={classes.menuItem}
                   >
                     {item.img && (
-                      <ListItemIcon className={classes.listIcon}>
+                      <ListItemIcon style={listIconStyles}>
                         {item.name === "Notifications" ? (
                           <Badge
                             badgeContent={notificationCount}
                             color="primary"
-                            classes={{ badge: classes.customBadge }}
+                            sx={customBadgeSx}
                           >
                             <img
-                              alt={"..."}
+                              alt={item.name}
                               src={item.img}
-                              className={classes.icons}
+                              style={iconStyles}
                             />
                           </Badge>
                         ) : (
                           <img
-                            alt={"..."}
+                            alt={item.name}
                             src={item.img}
-                            className={classes.icons}
+                            style={iconStyles}
                           />
                         )}
                       </ListItemIcon>
                     )}
                     <ListItemText
                       data-testId={item.name}
-                      style={{
-                        fontWeight:
-                          item?.id && value === item?.id ? "bold" : "normal",
-                        color:
-                          item?.link == location.pathname ? "#0293d9" : "black"
-                      }}
+                      style={textStyle}
                       disableTypography
                     >
                       {item.name}
                     </ListItemText>
-                  </MenuItem>
-                </NavLink>
+                  </StyledMenuItem>
+                </NavLinkStyled>
               )}
-              {!item.link && !item.onClick && (
-                <MenuItem
-                  key={item.name}
-                  onClick={() => {
-                    if (onStateChange !== undefined) onStateChange(item);
 
+              {!item.link && !item.onClick && (
+                <StyledMenuItem
+                  onClick={() => {
+                    onStateChange(item);
                     toggleSlider();
                   }}
-                  className={classes.menuItem}
                 >
                   {item.img && (
-                    <ListItemIcon className={classes.listIcon}>
+                    <ListItemIcon style={listIconStyles}>
                       <Badge
                         badgeContent={
                           notificationCount &&
                           (notificationCount > 99 ? "99+" : notificationCount)
                         }
                         color="primary"
-                        classes={{ badge: classes.customBadge }}
+                        sx={customBadgeSx}
                       >
-                        <NotificationsIcon className={classes.notification} />
+                        <NotificationsIcon style={{ color: "#000000" }} />
                       </Badge>
                     </ListItemIcon>
                   )}
                   <ListItemText
                     data-testId={item.name}
-                    style={{
-                      fontWeight:
-                        item?.id && value === item?.id ? "bold" : "normal",
-                      color:
-                        item?.link == location.pathname ? "#0293d9" : "black"
-                    }}
+                    style={textStyle}
                     disableTypography
                   >
                     {item.name}
                   </ListItemText>
-                </MenuItem>
+                </StyledMenuItem>
               )}
+
               {!item.link && item.onClick && (
-                <MenuItem
-                  key={item.name}
+                <StyledMenuItem
                   onClick={() => {
-                    if (item.onClick) item.onClick(item);
+                    item.onClick(item);
                     onStateChange(item);
                   }}
-                  className={classes.menuItem}
                 >
                   {item.img && (
-                    <ListItemIcon className={classes.listIcon}>
+                    <ListItemIcon style={listIconStyles}>
                       <img
-                        alt={"..."}
+                        alt={item.name}
                         src={item.img}
-                        className={classes.icons}
+                        style={iconStyles}
                       />
                     </ListItemIcon>
                   )}
                   <ListItemText
                     data-testId={item.name}
-                    style={{
-                      fontWeight:
-                        item?.id && value === item?.id ? "bold" : "normal",
-                      color:
-                        item?.link == location.pathname ? "#0293d9" : "black"
-                    }}
+                    style={textStyle}
                     disableTypography
                   >
                     {item.name}
                   </ListItemText>
-                </MenuItem>
+                </StyledMenuItem>
               )}
             </div>
           );
         })}
-        {children}
-      </MenuList>
-    </Paper>
+        {React.Children.map(children, (child, i) =>
+          child ? React.cloneElement(child, { key: `sidebar-child-${i}` }) : null
+        )}
+      </StyledMenuList>
+    </StyledPaper>
   );
 };
 


### PR DESCRIPTION
## Description
Fixes three pre-existing bugs in the SideBar component group, 
all related to the ongoing MUI v4 → v5 migration.

## Changes

**sidelist.jsx:**
- Fixed hardcoded `key="menu-items"` on every mapped div — every 
  item was getting the same key, causing duplicate key warnings
- Migrated from deprecated `makeStyles` (@mui/styles) to MUI v5 
  `styled()` API
- Fixed children rendering inside MenuList using React.Children.map 
  to avoid Fragment warning

**SideBar/index.jsx:**
- Removed Fragment wrapper (`<>...</>`) from return statement — 
  this was causing "MUI: Menu doesn't accept Fragment as child" warning
- Migrated from deprecated `makeStyles` to MUI v5 `styled()` API
- Simplified conditional rendering to return single elements directly

## Related Issue
Closes #314

## How Has This Been Tested?
- Ran npm run dev — no duplicate key warnings in console
- MUI Fragment warning resolved
- No functional regressions introduced
- App builds and runs correctly on localhost:5173

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)