### PR TITLE
refactor: migrate 404 error page from deprecated makeStyles to MUI v5 styled API

### DIFF
--- a/src/components/ErrorPages/404.jsx
+++ b/src/components/ErrorPages/404.jsx
@@ -41,7 +41,6 @@ const OopsList = styled("ul")(() => ({
   "& li:nth-of-type(10)": { transform: "rotate(20deg)" },
   "& li:nth-of-type(11)": { transform: "rotate(1deg)" }
 }));
-// ────────────────────────────────────────────────────────────────
 
 const NotFound = ({ background = "white", textColor = "black" }) => {
   return (

--- a/src/components/ErrorPages/404.jsx
+++ b/src/components/ErrorPages/404.jsx
@@ -1,77 +1,53 @@
 import React from "react";
 import errorImg from "../../assets/images/404.png";
-import { makeStyles } from "@mui/styles";
+import { styled } from "@mui/material/styles";
 import Grid from "@mui/material/Grid";
 import Typography from "@mui/material/Typography";
 
-const useStyles = makeStyles(theme => ({
-  wrapper: {
-    height: "65vh",
-    display: "flex",
-    alignItems: "center",
-    flexFlow: "column",
-    justifyContent: "center"
-  },
-  image: {
-    height: "10rem",
-    width: "20rem",
+const Wrapper = styled(Grid)(() => ({
+  height: "65vh",
+  display: "flex",
+  alignItems: "center",
+  flexFlow: "column",
+  justifyContent: "center"
+}));
 
-    alignItems: "center",
-    [theme.breakpoints.down(750)]: {
-      height: "10rem",
-      width: "15rem"
-    }
-  },
-  oops: {
-    listStyle: "none",
-    flexFlow: "row",
-    display: "flex",
-    marginLeft: "-3rem",
-    fontSize: "1.5rem",
-    color: "#465E66",
-    "& li:nth-child(1)": {
-      transform: "rotate(-190deg) translateY(-20px)"
-    },
-    "& li:nth-child(2)": {
-      transform: "rotate(-10deg)"
-    },
-    "& li:nth-child(3)": {
-      transform: "rotate(0deg)"
-    },
-    "& li:nth-child(4)": {
-      transform: "rotate(10deg)"
-    },
-    "& li:nth-child(5)": {
-      transform: "rotate(10deg)"
-    },
-    "& li:nth-child(6)": {
-      transform: "rotate(-10deg)"
-    },
-    "& li:nth-child(7)": {
-      transform: "rotate(10deg)"
-    },
-    "& li:nth-child(8)": {
-      transform: "rotate(10deg)"
-    },
-    "& li:nth-child(9)": {
-      transform: "rotate(20deg)"
-    },
-    "& li:nth-child(10)": {
-      transform: "rotate(20deg)"
-    },
-    "& li:nth-child(11)": {
-      transform: "rotate(1deg)"
-    }
+const ErrorImage = styled("img")(({ theme }) => ({
+  height: "10rem",
+  width: "20rem",
+  alignItems: "center",
+  [theme.breakpoints.down(750)]: {
+    height: "10rem",
+    width: "15rem"
   }
 }));
 
-const NotFound = ({ background = "white", textColor = "black" }) => {
-  const classes = useStyles();
+const OopsList = styled("ul")(() => ({
+  listStyle: "none",
+  flexFlow: "row",
+  display: "flex",
+  marginLeft: "-3rem",
+  fontSize: "1.5rem",
+  color: "#465E66",
+  "& li:nth-of-type(1)": { transform: "rotate(-190deg) translateY(-20px)" },
+  "& li:nth-of-type(2)": { transform: "rotate(-10deg)" },
+  "& li:nth-of-type(3)": { transform: "rotate(0deg)" },
+  "& li:nth-of-type(4)": { transform: "rotate(10deg)" },
+  "& li:nth-of-type(5)": { transform: "rotate(10deg)" },
+  "& li:nth-of-type(6)": { transform: "rotate(-10deg)" },
+  "& li:nth-of-type(7)": { transform: "rotate(10deg)" },
+  "& li:nth-of-type(8)": { transform: "rotate(10deg)" },
+  "& li:nth-of-type(9)": { transform: "rotate(20deg)" },
+  "& li:nth-of-type(10)": { transform: "rotate(20deg)" },
+  "& li:nth-of-type(11)": { transform: "rotate(1deg)" }
+}));
+// ────────────────────────────────────────────────────────────────
 
+const NotFound = ({ background = "white", textColor = "black" }) => {
   return (
-    <Grid
+    <Wrapper
       container
-      className={`row-fullheight ${classes.wrapper}`}
+      className="row-fullheight"
       style={{ background: background }}
       data-testId="errorPage"
     >
@@ -79,7 +55,7 @@ const NotFound = ({ background = "white", textColor = "black" }) => {
         item
         style={{ padding: "0", marginTop: "-5rem", marginLeft: "2rem" }}
       >
-        <img className={classes.image} src={errorImg} alt="error" />
+        <ErrorImage src={errorImg} alt="404 error - page not found" />
       </Grid>
       <Grid
         item
@@ -90,7 +66,7 @@ const NotFound = ({ background = "white", textColor = "black" }) => {
         </Typography>
       </Grid>
       <Grid item>
-        <ul className={classes.oops} style={{ color: textColor }}>
+        <OopsList style={{ color: textColor }}>
           <li>P</li>
           <li>A</li>
           <li>G</li>
@@ -102,14 +78,14 @@ const NotFound = ({ background = "white", textColor = "black" }) => {
           <li>K</li>
           <li>E</li>
           <li>N</li>
-        </ul>
+        </OopsList>
       </Grid>
       <Grid item style={{ marginTop: "0" }}>
         <Typography variant="body" style={{ color: textColor }}>
           We can't seem to find the page you are looking for
         </Typography>
       </Grid>
-    </Grid>
+    </Wrapper>
   );
 };
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

Migrates src/components/ErrorPages/404.jsx from the deprecated @mui/styles makeStyles API to the MUI v5 styled() API. Removes the inline useStyles hook and replaces className references with three styled components: Wrapper, ErrorImage, and OopsList. Also updates nth-child selectors to nth-of-type and improves image alt text for accessibility.

## Related Issue

Part of #314 (refactor: Migrate deprecated MUI v4 components to MUI v5)

## Motivation and Context

The codebase still uses makeStyles from @mui/styles in several components. This is one of the causes of the peer dependency conflicts during npm install and blocks the full TypeScript migration. Migrating to the MUI v5 styled() API removes the deprecated dependency usage and brings the component in line with the rest of the ongoing migration effort.

## How Has This Been Tested?

- Navigated to a non-existent route (localhost:5173/test) to trigger the 404 page
- Page renders correctly with no visual regression
- No new console errors introduced by this change
- npm run dev runs successfully

## Screenshots or GIF (In case of UI changes):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
