### PR TITLE
refactor: migrate FooterLinks from makeStyles to MUI v5 styled API, fix missing key prop and remove unused import

### DIFF
--- a/src/components/FooterLinks/index.jsx
+++ b/src/components/FooterLinks/index.jsx
@@ -1,51 +1,47 @@
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
 import Chip from "@mui/material/Chip";
-import Typography from "@mui/material/Typography";
-import React, { useEffect } from "react";
-import { makeStyles } from "@mui/styles";
+import React from "react";
+import { styled } from "@mui/material/styles";
 
-const useStyles = makeStyles(theme => ({
-  root: {
-    display: "flex",
-    justifyContent: "center",
-    flexWrap: "wrap",
-    "& > *": {
-      margin: theme.spacing(0.5)
-    },
-    marginBottom: "1rem",
-    border: "none",
-    backgroundColor: "transparent",
-    boxShadow: "none"
+const StyledCard = styled(Card)(({ theme }) => ({
+  display: "flex",
+  justifyContent: "center",
+  flexWrap: "wrap",
+  "& > *": {
+    margin: theme.spacing(0.5)
   },
-  chip: {
-    margin: "0px 10px 10px 0px",
-    backgroundColor: "transparent",
-    border: "none",
-    cursor: "pointer"
-  }
+  marginBottom: "1rem",
+  border: "none",
+  backgroundColor: "transparent",
+  boxShadow: "none"
+}));
+
+const StyledChip = styled(Chip)(() => ({
+  margin: "0px 10px 10px 0px",
+  backgroundColor: "transparent",
+  border: "none",
+  cursor: "pointer"
 }));
 
 const FooterLinks = props => {
-  const classes = useStyles();
-
   return (
-    <Card className={classes.root}>
+    <StyledCard>
       <CardContent>
         {props.elements.map(function (el, index) {
           return (
-            <a href={el.link}>
-              <Chip
+            // Fix: added key prop to prevent React duplicate key warning
+            <a key={el.link || index} href={el.link}>
+              <StyledChip
                 size="small"
                 label={el.name}
                 id={index}
-                className={classes.chip}
               />
             </a>
           );
         })}
       </CardContent>
-    </Card>
+    </StyledCard>
   );
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Migrates src/components/FooterLinks/index.jsx from deprecated @mui/styles makeStyles to MUI v5 styled() API as part of #314.

## Related Issue

Part of #314

## Motivation and Context

Three issues fixed in one PR: deprecated makeStyles removed and replaced with styled() API, missing key prop added to mapped anchor elements (was causing React duplicate key warning), and unused useEffect import removed.

## How Has This Been Tested?

- Ran npm run dev successfully
- App runs with no new console errors introduced
- No visual regression on pages that use this component

## Screenshots or GIF (In case of UI changes):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
