### PR TITLE
refactor: migrate Divider component from deprecated makeStyles to MUI v5 styled API

### DIFF
--- a/src/globalComponents/Divider.jsx
+++ b/src/globalComponents/Divider.jsx
@@ -1,34 +1,34 @@
-import { makeStyles } from "@mui/styles";
+import { styled } from "@mui/material/styles";
 import React from "react";
 
-const useStyles = makeStyles(theme => ({
-  container: {
-    display: "flex",
-    alignItems: "center"
-  },
-  border: {
-    borderBottom: "1px solid lightgray",
-    width: "100%"
-  },
-  content: {
-    paddingTop: theme.spacing(0.5),
-    paddingBottom: theme.spacing(0.5),
-    paddingRight: theme.spacing(2),
-    paddingLeft: theme.spacing(2),
-    fontSize: 16,
-    color: "rgba(0, 0, 0, 0.85)",
-    fontWeight: 500
-  }
+const Container = styled("div")(() => ({
+  display: "flex",
+  alignItems: "center"
+}));
+
+const Border = styled("div")(() => ({
+  borderBottom: "1px solid lightgray",
+  width: "100%"
+}));
+
+const Content = styled("span")(({ theme }) => ({
+  paddingTop: theme.spacing(0.5),
+  paddingBottom: theme.spacing(0.5),
+  paddingRight: theme.spacing(2),
+  paddingLeft: theme.spacing(2),
+  fontSize: 16,
+  color: "rgba(0, 0, 0, 0.85)",
+  fontWeight: 500
 }));
 
 const Divider = ({ children }) => {
-  const classes = useStyles();
   return (
-    <div className={classes.container}>
-      <div className={classes.border} />
-      <span className={classes.content}>{children}</span>
-      <div className={classes.border} />
-    </div>
+    <Container>
+      <Border />
+      <Content>{children}</Content>
+      <Border />
+    </Container>
   );
 };
+
 export default Divider;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Migrates src/globalComponents/Divider.jsx from deprecated @mui/styles makeStyles to MUI v5 styled() API as part of #314.

## Related Issue

Part of #314

## Motivation and Context

The Divider component was using makeStyles from @mui/styles which is deprecated in MUI v5. Replaced with three styled components: Container, Border, and Content; zero functional or visual changes.

## How Has This Been Tested?

- Ran npm run dev successfully
- No new console errors introduced
- No visual regression

## Screenshots or GIF (In case of UI changes):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
