### PR TITLE
fix: correct CODE_OF_CONDUCT.md  filename case in README (#390)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Contributions are always welcome!
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for ways to get started.
 
-Please adhere to this project's [code of conduct](./code_of_conduct.md).
+Please adhere to this project's [code of conduct](./CODE_OF_CONDUCT.md).
 
 # FAQs
 


### PR DESCRIPTION
## Description
Fixed the broken CODE_OF_CONDUCT.md link in README.md. The link was using incorrect lowercase filename (code_of_conduct.md) which returned a 404 error. Changed to correct uppercase filename (CODE_OF_CONDUCT.md).

## Related Issue
Fixes #390

## Motivation and Context
The code of conduct link in the Contribute section of README.md was broken and returning 404 for all users clicking it. This fix ensures the link correctly points to the existing CODE_OF_CONDUCT.md file.

## How Has This Been Tested?
Clicked the updated link in README.md and verified it correctly navigates to the CODE_OF_CONDUCT.md file without any 404 error.

## Screenshots or GIF
Not applicable — documentation fix only.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.