### PR TITLE
fix: add missing await to checkUserHandleExists to enforce duplicate …

### DIFF
--- a/src/store/actions/profileActions.js
+++ b/src/store/actions/profileActions.js
@@ -160,7 +160,7 @@ export const getUserProfileData =
   handle => async (firebase, firestore, dispatch) => {
     try {
       dispatch({ type: actions.GET_USER_DATA_START });
-      const isUserExists = checkUserHandleExists(handle)(firebase);
+      const isUserExists = await checkUserHandleExists(handle)(firebase);
       if (isUserExists) {
         const docs = await firestore
           .collection("cl_user")


### PR DESCRIPTION
**Description:**

This PR fixes a bug in `getUserProfileData` where `checkUserHandleExists` was called without `await`. Since the returned Promise is always truthy, the existence check always passed regardless of whether the handle actually existed, causing the app to attempt fetching profile data even for non-existent handles.

- Added `await` to `checkUserHandleExists(handle)(firebase)` so the actual boolean result is checked

Closes #414 