### PR TITLE
fix: guard previewCanvasRef.current before calling getContext

### DIFF
--- a/src/components/Profile/ChangeProfile/ChangeProfile.jsx
+++ b/src/components/Profile/ChangeProfile/ChangeProfile.jsx
@@ -97,7 +97,7 @@ export default function ChangeProfile({ open, saveImage, onClose }) {
   };
 
   useEffect(() => {
-    if (upImg && previewCanvasRef) {
+    if (upImg && previewCanvasRef.current) {
       const context = previewCanvasRef.current.getContext("2d");
 
       UpdateImage(context);


### PR DESCRIPTION
**Changes**
 
* Changed `if (upImg && previewCanvasRef)` to `if (upImg && previewCanvasRef.current)` so the canvas context is only accessed after the DOM node is mounted

Fixes #423  
 