### PR TITLE
fix: pass handleCancel function to Dialog onClose instead of !handleC…

### DIFF
--- a/src/components/Organization/OrgSidebar/createOrgModal.jsx
+++ b/src/components/Organization/OrgSidebar/createOrgModal.jsx
@@ -90,7 +90,7 @@ const CreateOrgModal = props => {
   return (
     <Dialog
       open={visible}
-      onClose={!handleCancel}
+      onClose={handleCancel}
       style={{
         zIndex: "1"
       }}


### PR DESCRIPTION
 **Changes**
 * Changed `onClose={!handleCancel}` to `onClose={handleCancel}` so the modal correctly closes on backdrop click and Escape key
 
 Fixes #425 