### PR TITLE
fix(Notification): initialize state with empty array fallback to prev…

### DIFF
--- a/src/components/Notification/index.jsx
+++ b/src/components/Notification/index.jsx
@@ -82,7 +82,9 @@ const Notification = ({ background = "white", textColor = "black" }) => {
   const notifications = useSelector(
     state => state.notifications.data.notifications
   );
-  const [localNotifications, setLocalNotifications] = useState(notifications);
+  const [localNotifications, setLocalNotifications] = useState(
+    notifications ?? []
+  );
 
   // for instant UI update
   const handleNotificationDelete = id => {
@@ -99,7 +101,7 @@ const Notification = ({ background = "white", textColor = "black" }) => {
     };
 
     getNotifications();
-    setLocalNotifications(notifications);
+    setLocalNotifications(notifications ?? []);
   }, [firebase, firestore, dispatch]);
 
   return (

--- a/src/components/Notification/index.jsx
+++ b/src/components/Notification/index.jsx
@@ -101,8 +101,11 @@ const Notification = ({ background = "white", textColor = "black" }) => {
     };
 
     getNotifications();
-    setLocalNotifications(notifications ?? []);
   }, [firebase, firestore, dispatch]);
+
+  useEffect(() => {
+    setLocalNotifications(notifications ?? []);
+  }, [notifications]);
 
   return (
     <>


### PR DESCRIPTION
**Changes**
 
* Changed `useState(notifications)` to `useState(notifications ?? [])` so the initial state is always an array
* Changed `setLocalNotifications(notifications)` to `setLocalNotifications(notifications ?? [])` for the same guard on the effect update
Fixes #427 