### PR TITLE
fix: cleanup orphaned users and sync Redux state on organization delete

### DIFF
--- a/src/components/Organization/OrgUsers/OrgDeleteModal.jsx
+++ b/src/components/Organization/OrgUsers/OrgDeleteModal.jsx
@@ -52,9 +52,13 @@ function OrgDeleteModal() {
   );
 
   const deleteOrganizationHandler = useCallback(async () => {
-    await deleteOrganization(CurrentOrg.org_handle)(firebase, dispatch);
-    await getProfileData()(firebase, firestore, dispatch);
-    history.push("/");
+    try {
+      await deleteOrganization(CurrentOrg.org_handle)(firebase, dispatch);
+      await getProfileData()(firebase, firestore, dispatch);
+      history.push("/");
+    } catch (e) {
+      console.log(e);
+    }
   }, [CurrentOrg.org_handle, dispatch, firebase, firestore, history]);
 
   return (

--- a/src/components/Organization/OrgUsers/OrgDeleteModal.jsx
+++ b/src/components/Organization/OrgUsers/OrgDeleteModal.jsx
@@ -11,9 +11,9 @@ import React from "react";
 import { useCallback } from "react";
 import { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { useFirebase } from "react-redux-firebase";
+import { deleteOrganization, getProfileData } from "../../../store/actions";
+import { useFirebase, useFirestore } from "react-redux-firebase";
 import { useHistory } from "react-router-dom";
-import { deleteOrganization } from "../../../store/actions/orgActions";
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -35,6 +35,7 @@ function OrgDeleteModal() {
   const history = useHistory("/");
   const firebase = useFirebase();
   const dispatch = useDispatch();
+  const firestore = useFirestore();
 
   const [deleteOrgInput, setDeleteOrgInput] = React.useState("");
 
@@ -52,8 +53,9 @@ function OrgDeleteModal() {
 
   const deleteOrganizationHandler = useCallback(async () => {
     await deleteOrganization(CurrentOrg.org_handle)(firebase, dispatch);
+    await getProfileData()(firebase, firestore, dispatch);
     history.push("/");
-  }, [CurrentOrg.org_handle, dispatch, firebase, history]);
+  }, [CurrentOrg.org_handle, dispatch, firebase, firestore, history]);
 
   return (
     <React.Fragment>

--- a/src/store/actions/orgActions.js
+++ b/src/store/actions/orgActions.js
@@ -1,5 +1,4 @@
 import _ from "lodash";
-import { useFirebase } from "react-redux-firebase";
 import Elasticlunr from "../../helpers/elasticlunr";
 import * as actions from "./actionTypes";
 import { checkOrgHandleExists } from "./authActions";
@@ -46,68 +45,68 @@ export const getOrgUserData = org_handle => async (firestore, dispatch) => {
 // adds a user to organization's users list with a set of permissions
 export const addOrgUser =
   ({ org_handle, handle, permissions }) =>
-  async (firestore, dispatch) => {
-    try {
-      dispatch({ type: actions.ADD_ORG_USER_START });
-      const userDoc = await firestore
-        .collection("cl_user")
-        .where("handle", "==", handle)
-        .get();
-      if (userDoc.docs.length === 1) {
-        const uid = userDoc.docs[0].get("uid");
-        await firestore
-          .collection("org_users")
-          .doc(`${org_handle}_${uid}`)
-          .set({
-            uid: uid,
-            org_handle: org_handle,
-            permissions: permissions
-          });
+    async (firestore, dispatch) => {
+      try {
+        dispatch({ type: actions.ADD_ORG_USER_START });
+        const userDoc = await firestore
+          .collection("cl_user")
+          .where("handle", "==", handle)
+          .get();
+        if (userDoc.docs.length === 1) {
+          const uid = userDoc.docs[0].get("uid");
+          await firestore
+            .collection("org_users")
+            .doc(`${org_handle}_${uid}`)
+            .set({
+              uid: uid,
+              org_handle: org_handle,
+              permissions: permissions
+            });
 
-        await getOrgUserData(org_handle)(firestore, dispatch);
-        dispatch({ type: actions.ADD_ORG_USER_SUCCESS });
-      } else {
-        dispatch({
-          type: actions.ADD_ORG_USER_FAIL,
-          payload: `User [${handle}] is not registered with CodeLabz`
-        });
+          await getOrgUserData(org_handle)(firestore, dispatch);
+          dispatch({ type: actions.ADD_ORG_USER_SUCCESS });
+        } else {
+          dispatch({
+            type: actions.ADD_ORG_USER_FAIL,
+            payload: `User [${handle}] is not registered with CodeLabz`
+          });
+        }
+      } catch (e) {
+        console.log(e);
+        dispatch({ type: actions.ADD_ORG_USER_FAIL, payload: e.message });
       }
-    } catch (e) {
-      console.log(e);
-      dispatch({ type: actions.ADD_ORG_USER_FAIL, payload: e.message });
-    }
-  };
+    };
 
 // removes all permissions of a user from an organization
 export const removeOrgUser =
   ({ org_handle, handle }) =>
-  async (firestore, dispatch) => {
-    try {
-      dispatch({ type: actions.ADD_ORG_USER_START });
-      const userDoc = await firestore
-        .collection("cl_user")
-        .where("handle", "==", handle)
-        .get();
-      if (userDoc.docs.length === 1) {
-        const uid = userDoc.docs[0].get("uid");
-        await firestore
-          .collection("org_users")
-          .doc(`${org_handle}_${uid}`)
-          .delete();
+    async (firestore, dispatch) => {
+      try {
+        dispatch({ type: actions.ADD_ORG_USER_START });
+        const userDoc = await firestore
+          .collection("cl_user")
+          .where("handle", "==", handle)
+          .get();
+        if (userDoc.docs.length === 1) {
+          const uid = userDoc.docs[0].get("uid");
+          await firestore
+            .collection("org_users")
+            .doc(`${org_handle}_${uid}`)
+            .delete();
 
-        await getOrgUserData(org_handle)(firestore, dispatch);
-        dispatch({ type: actions.ADD_ORG_USER_SUCCESS });
-      } else {
-        dispatch({
-          type: actions.ADD_ORG_USER_FAIL,
-          payload: `User [${handle}] is not registered with CodeLabz`
-        });
+          await getOrgUserData(org_handle)(firestore, dispatch);
+          dispatch({ type: actions.ADD_ORG_USER_SUCCESS });
+        } else {
+          dispatch({
+            type: actions.ADD_ORG_USER_FAIL,
+            payload: `User [${handle}] is not registered with CodeLabz`
+          });
+        }
+      } catch (e) {
+        console.log(e);
+        dispatch({ type: actions.ADD_ORG_USER_FAIL, payload: e.message });
       }
-    } catch (e) {
-      console.log(e);
-      dispatch({ type: actions.ADD_ORG_USER_FAIL, payload: e.message });
-    }
-  };
+    };
 
 export const getOrgBasicData = org_handle => async firebase => {
   try {
@@ -141,7 +140,7 @@ export const getOrgBasicData = org_handle => async firebase => {
     };
   } catch (e) {
     console.log(e);
-    throw e;
+    return null;
   }
 };
 
@@ -178,26 +177,26 @@ export const clearEditGeneral = () => dispatch => {
 
 export const unPublishOrganization =
   (org_handle, published, currentOrgData) =>
-  async (firebase, firestore, dispatch) => {
-    try {
-      dispatch({ type: actions.EDIT_ORG_GENERAL_START });
-      await firestore.collection("cl_org_general").doc(org_handle).update({
-        org_published: !published,
-        updatedAt: firestore.FieldValue.serverTimestamp()
-      });
+    async (firebase, firestore, dispatch) => {
+      try {
+        dispatch({ type: actions.EDIT_ORG_GENERAL_START });
+        await firestore.collection("cl_org_general").doc(org_handle).update({
+          org_published: !published,
+          updatedAt: firestore.FieldValue.serverTimestamp()
+        });
 
-      const newData = await getOrgBasicData(org_handle)(firebase);
-      const update = _.unionBy([newData], currentOrgData, "org_handle");
-      dispatch({
-        type: actions.GET_PROFILE_DATA_SUCCESS,
-        payload: { organizations: _.orderBy(update, ["org_handle"], ["asc"]) }
-      });
+        const newData = await getOrgBasicData(org_handle)(firebase);
+        const update = _.unionBy([newData], currentOrgData, "org_handle");
+        dispatch({
+          type: actions.GET_PROFILE_DATA_SUCCESS,
+          payload: { organizations: _.orderBy(update, ["org_handle"], ["asc"]) }
+        });
 
-      dispatch({ type: actions.EDIT_ORG_GENERAL_SUCCESS });
-    } catch (e) {
-      dispatch({ type: actions.EDIT_ORG_GENERAL_FAIL, payload: e.message });
-    }
-  };
+        dispatch({ type: actions.EDIT_ORG_GENERAL_SUCCESS });
+      } catch (e) {
+        dispatch({ type: actions.EDIT_ORG_GENERAL_FAIL, payload: e.message });
+      }
+    };
 
 export const uploadOrgProfileImage =
   (file, org_handle, currentOrgData) => async (firebase, dispatch) => {
@@ -401,35 +400,38 @@ export const addFollower =
 
 export const deleteOrganization =
   org_handle =>
-  async (firebase, dispatch) => {
-    try {
-      const auth = firebase.auth().currentUser;
+    async (firebase, dispatch) => {
+      try {
+        dispatch({ type: actions.DELETE_ORG_START });
 
-      await firebase
-        .firestore()
-        .collection("cl_org_general")
-        .doc(org_handle)
-        .delete();
+        const auth = firebase.auth().currentUser;
+        const db = firebase.firestore();
 
-      await firebase
-        .firestore()
-        .collection("cl_user")
-        .doc(auth.uid)
-        .update({
+        const orgUsersSnap = await db
+          .collection("org_users")
+          .where("org_handle", "==", org_handle)
+          .get();
+
+        const batch = db.batch();
+
+        orgUsersSnap.docs.forEach(doc => {
+          batch.delete(doc.ref);
+        });
+
+        batch.update(db.collection("cl_user").doc(auth.uid), {
           organizations: firebase.firestore.FieldValue.arrayRemove(org_handle)
         });
 
-      const orgUsersSnap = await firebase
-        .firestore()
-        .collection("org_users")
-        .where("org_handle", "==", org_handle)
-        .get();
+        batch.delete(db.collection("cl_org_general").doc(org_handle));
 
-      await Promise.all(orgUsersSnap.docs.map(doc => doc.ref.delete()));
+        await batch.commit();
 
-      dispatch({ type: actions.CLEAR_ORG_GENERAL_STATE });
-      dispatch({ type: actions.CLEAR_ORG_USER_STATE });
-    } catch (e) {
-      console.log(e);
-    }
-  };
+        dispatch({ type: actions.DELETE_ORG_SUCCESS });
+        dispatch({ type: actions.CLEAR_ORG_GENERAL_STATE });
+        dispatch({ type: actions.CLEAR_ORG_USER_STATE });
+        return true;
+      } catch (e) {
+        dispatch({ type: actions.DELETE_ORG_FAIL, payload: e.message });
+        throw e;
+      }
+    };

--- a/src/store/actions/orgActions.js
+++ b/src/store/actions/orgActions.js
@@ -45,68 +45,68 @@ export const getOrgUserData = org_handle => async (firestore, dispatch) => {
 // adds a user to organization's users list with a set of permissions
 export const addOrgUser =
   ({ org_handle, handle, permissions }) =>
-    async (firestore, dispatch) => {
-      try {
-        dispatch({ type: actions.ADD_ORG_USER_START });
-        const userDoc = await firestore
-          .collection("cl_user")
-          .where("handle", "==", handle)
-          .get();
-        if (userDoc.docs.length === 1) {
-          const uid = userDoc.docs[0].get("uid");
-          await firestore
-            .collection("org_users")
-            .doc(`${org_handle}_${uid}`)
-            .set({
-              uid: uid,
-              org_handle: org_handle,
-              permissions: permissions
-            });
-
-          await getOrgUserData(org_handle)(firestore, dispatch);
-          dispatch({ type: actions.ADD_ORG_USER_SUCCESS });
-        } else {
-          dispatch({
-            type: actions.ADD_ORG_USER_FAIL,
-            payload: `User [${handle}] is not registered with CodeLabz`
+  async (firestore, dispatch) => {
+    try {
+      dispatch({ type: actions.ADD_ORG_USER_START });
+      const userDoc = await firestore
+        .collection("cl_user")
+        .where("handle", "==", handle)
+        .get();
+      if (userDoc.docs.length === 1) {
+        const uid = userDoc.docs[0].get("uid");
+        await firestore
+          .collection("org_users")
+          .doc(`${org_handle}_${uid}`)
+          .set({
+            uid: uid,
+            org_handle: org_handle,
+            permissions: permissions
           });
-        }
-      } catch (e) {
-        console.log(e);
-        dispatch({ type: actions.ADD_ORG_USER_FAIL, payload: e.message });
+
+        await getOrgUserData(org_handle)(firestore, dispatch);
+        dispatch({ type: actions.ADD_ORG_USER_SUCCESS });
+      } else {
+        dispatch({
+          type: actions.ADD_ORG_USER_FAIL,
+          payload: `User [${handle}] is not registered with CodeLabz`
+        });
       }
-    };
+    } catch (e) {
+      console.log(e);
+      dispatch({ type: actions.ADD_ORG_USER_FAIL, payload: e.message });
+    }
+  };
 
 // removes all permissions of a user from an organization
 export const removeOrgUser =
   ({ org_handle, handle }) =>
-    async (firestore, dispatch) => {
-      try {
-        dispatch({ type: actions.ADD_ORG_USER_START });
-        const userDoc = await firestore
-          .collection("cl_user")
-          .where("handle", "==", handle)
-          .get();
-        if (userDoc.docs.length === 1) {
-          const uid = userDoc.docs[0].get("uid");
-          await firestore
-            .collection("org_users")
-            .doc(`${org_handle}_${uid}`)
-            .delete();
+  async (firestore, dispatch) => {
+    try {
+      dispatch({ type: actions.ADD_ORG_USER_START });
+      const userDoc = await firestore
+        .collection("cl_user")
+        .where("handle", "==", handle)
+        .get();
+      if (userDoc.docs.length === 1) {
+        const uid = userDoc.docs[0].get("uid");
+        await firestore
+          .collection("org_users")
+          .doc(`${org_handle}_${uid}`)
+          .delete();
 
-          await getOrgUserData(org_handle)(firestore, dispatch);
-          dispatch({ type: actions.ADD_ORG_USER_SUCCESS });
-        } else {
-          dispatch({
-            type: actions.ADD_ORG_USER_FAIL,
-            payload: `User [${handle}] is not registered with CodeLabz`
-          });
-        }
-      } catch (e) {
-        console.log(e);
-        dispatch({ type: actions.ADD_ORG_USER_FAIL, payload: e.message });
+        await getOrgUserData(org_handle)(firestore, dispatch);
+        dispatch({ type: actions.ADD_ORG_USER_SUCCESS });
+      } else {
+        dispatch({
+          type: actions.ADD_ORG_USER_FAIL,
+          payload: `User [${handle}] is not registered with CodeLabz`
+        });
       }
-    };
+    } catch (e) {
+      console.log(e);
+      dispatch({ type: actions.ADD_ORG_USER_FAIL, payload: e.message });
+    }
+  };
 
 export const getOrgBasicData = org_handle => async firebase => {
   try {
@@ -177,26 +177,26 @@ export const clearEditGeneral = () => dispatch => {
 
 export const unPublishOrganization =
   (org_handle, published, currentOrgData) =>
-    async (firebase, firestore, dispatch) => {
-      try {
-        dispatch({ type: actions.EDIT_ORG_GENERAL_START });
-        await firestore.collection("cl_org_general").doc(org_handle).update({
-          org_published: !published,
-          updatedAt: firestore.FieldValue.serverTimestamp()
-        });
+  async (firebase, firestore, dispatch) => {
+    try {
+      dispatch({ type: actions.EDIT_ORG_GENERAL_START });
+      await firestore.collection("cl_org_general").doc(org_handle).update({
+        org_published: !published,
+        updatedAt: firestore.FieldValue.serverTimestamp()
+      });
 
-        const newData = await getOrgBasicData(org_handle)(firebase);
-        const update = _.unionBy([newData], currentOrgData, "org_handle");
-        dispatch({
-          type: actions.GET_PROFILE_DATA_SUCCESS,
-          payload: { organizations: _.orderBy(update, ["org_handle"], ["asc"]) }
-        });
+      const newData = await getOrgBasicData(org_handle)(firebase);
+      const update = _.unionBy([newData], currentOrgData, "org_handle");
+      dispatch({
+        type: actions.GET_PROFILE_DATA_SUCCESS,
+        payload: { organizations: _.orderBy(update, ["org_handle"], ["asc"]) }
+      });
 
-        dispatch({ type: actions.EDIT_ORG_GENERAL_SUCCESS });
-      } catch (e) {
-        dispatch({ type: actions.EDIT_ORG_GENERAL_FAIL, payload: e.message });
-      }
-    };
+      dispatch({ type: actions.EDIT_ORG_GENERAL_SUCCESS });
+    } catch (e) {
+      dispatch({ type: actions.EDIT_ORG_GENERAL_FAIL, payload: e.message });
+    }
+  };
 
 export const uploadOrgProfileImage =
   (file, org_handle, currentOrgData) => async (firebase, dispatch) => {
@@ -400,38 +400,38 @@ export const addFollower =
 
 export const deleteOrganization =
   org_handle =>
-    async (firebase, dispatch) => {
-      try {
-        dispatch({ type: actions.DELETE_ORG_START });
+  async (firebase, dispatch) => {
+    try {
+      dispatch({ type: actions.DELETE_ORG_START });
 
-        const auth = firebase.auth().currentUser;
-        const db = firebase.firestore();
+      const auth = firebase.auth().currentUser;
+      const db = firebase.firestore();
 
-        const orgUsersSnap = await db
-          .collection("org_users")
-          .where("org_handle", "==", org_handle)
-          .get();
+      const orgUsersSnap = await db
+        .collection("org_users")
+        .where("org_handle", "==", org_handle)
+        .get();
 
-        const batch = db.batch();
+      const batch = db.batch();
 
-        orgUsersSnap.docs.forEach(doc => {
-          batch.delete(doc.ref);
-        });
+      orgUsersSnap.docs.forEach(doc => {
+        batch.delete(doc.ref);
+      });
 
-        batch.update(db.collection("cl_user").doc(auth.uid), {
-          organizations: firebase.firestore.FieldValue.arrayRemove(org_handle)
-        });
+      batch.update(db.collection("cl_user").doc(auth.uid), {
+        organizations: firebase.firestore.FieldValue.arrayRemove(org_handle)
+      });
 
-        batch.delete(db.collection("cl_org_general").doc(org_handle));
+      batch.delete(db.collection("cl_org_general").doc(org_handle));
 
-        await batch.commit();
+      await batch.commit();
 
-        dispatch({ type: actions.DELETE_ORG_SUCCESS });
-        dispatch({ type: actions.CLEAR_ORG_GENERAL_STATE });
-        dispatch({ type: actions.CLEAR_ORG_USER_STATE });
-        return true;
-      } catch (e) {
-        dispatch({ type: actions.DELETE_ORG_FAIL, payload: e.message });
-        throw e;
-      }
-    };
+      dispatch({ type: actions.DELETE_ORG_SUCCESS });
+      dispatch({ type: actions.CLEAR_ORG_GENERAL_STATE });
+      dispatch({ type: actions.CLEAR_ORG_USER_STATE });
+      return true;
+    } catch (e) {
+      dispatch({ type: actions.DELETE_ORG_FAIL, payload: e.message });
+      throw e;
+    }
+  };

--- a/src/store/actions/orgActions.js
+++ b/src/store/actions/orgActions.js
@@ -401,17 +401,16 @@ export const addFollower =
 
 export const deleteOrganization =
   org_handle =>
-  async (firebase = useFirebase(), dispatch) => {
+  async (firebase, dispatch) => {
     try {
       const auth = firebase.auth().currentUser;
-      // remove org from the organization collection
+
       await firebase
         .firestore()
         .collection("cl_org_general")
         .doc(org_handle)
         .delete();
 
-      // remove org from the user's orgs
       await firebase
         .firestore()
         .collection("cl_user")
@@ -419,6 +418,15 @@ export const deleteOrganization =
         .update({
           organizations: firebase.firestore.FieldValue.arrayRemove(org_handle)
         });
+
+      const orgUsersSnap = await firebase
+        .firestore()
+        .collection("org_users")
+        .where("org_handle", "==", org_handle)
+        .get();
+
+      await Promise.all(orgUsersSnap.docs.map(doc => doc.ref.delete()));
+
       dispatch({ type: actions.CLEAR_ORG_GENERAL_STATE });
       dispatch({ type: actions.CLEAR_ORG_USER_STATE });
     } catch (e) {

--- a/src/store/actions/profileActions.js
+++ b/src/store/actions/profileActions.js
@@ -32,29 +32,24 @@ export const getProfileData = () => async (firebase, firestore, dispatch) => {
       firestore,
       dispatch
     );
-    const organizations = userOrgs?.map(org => org.org_handle);
-    if (organizations && organizations.length > 0) {
-      const promises = organizations.map(org_handle =>
-        getOrgBasicData(org_handle)(firebase)
-      );
-      const resolvedOrgs = await Promise.all(promises);
-      const orgs = resolvedOrgs.filter(org => org !== null);
+    const promises =
+      userOrgs?.map(org => getOrgBasicData(org.org_handle)(firebase)) ?? [];
+    const orgs = await Promise.all(promises).then(results =>
+      results.filter(Boolean)
+    );
 
-      if (orgs.length > 0) {
-        setCurrentOrgUserPermissions(
-          orgs[0].org_handle,
-          orgs[0].permissions
-        )(dispatch);
-        dispatch({
-          type: actions.GET_PROFILE_DATA_SUCCESS,
-          payload: { organizations: _.orderBy(orgs, ["permissions"], ["desc"]) }
-        });
-      } else {
-        dispatch({ type: actions.GET_PROFILE_DATA_END });
-      }
-    } else {
+    if (orgs.length === 0) {
       dispatch({ type: actions.GET_PROFILE_DATA_END });
+      return;
     }
+
+    setCurrentOrgUserPermissions(orgs[0].org_handle, orgs[0].permissions)(
+      dispatch
+    );
+    dispatch({
+      type: actions.GET_PROFILE_DATA_SUCCESS,
+      payload: { organizations: _.orderBy(orgs, ["permissions"], ["desc"]) }
+    });
   } catch (e) {
     dispatch({ type: actions.GET_PROFILE_DATA_FAIL, payload: e.message });
   }

--- a/src/store/actions/profileActions.js
+++ b/src/store/actions/profileActions.js
@@ -33,20 +33,25 @@ export const getProfileData = () => async (firebase, firestore, dispatch) => {
       dispatch
     );
     const organizations = userOrgs?.map(org => org.org_handle);
-    // console.log(organizations);
     if (organizations && organizations.length > 0) {
       const promises = organizations.map(org_handle =>
         getOrgBasicData(org_handle)(firebase)
       );
-      const orgs = await Promise.all(promises);
-      setCurrentOrgUserPermissions(
-        orgs[0].org_handle,
-        orgs[0].permissions
-      )(dispatch);
-      dispatch({
-        type: actions.GET_PROFILE_DATA_SUCCESS,
-        payload: { organizations: _.orderBy(orgs, ["permissions"], ["desc"]) }
-      });
+      const resolvedOrgs = await Promise.all(promises);
+      const orgs = resolvedOrgs.filter(org => org !== null);
+
+      if (orgs.length > 0) {
+        setCurrentOrgUserPermissions(
+          orgs[0].org_handle,
+          orgs[0].permissions
+        )(dispatch);
+        dispatch({
+          type: actions.GET_PROFILE_DATA_SUCCESS,
+          payload: { organizations: _.orderBy(orgs, ["permissions"], ["desc"]) }
+        });
+      } else {
+        dispatch({ type: actions.GET_PROFILE_DATA_END });
+      }
     } else {
       dispatch({ type: actions.GET_PROFILE_DATA_END });
     }

--- a/src/store/reducers/profileReducer/dataReducer.js
+++ b/src/store/reducers/profileReducer/dataReducer.js
@@ -40,7 +40,8 @@ const ProfileDataReducer = (state = initialState, { type, payload }) => {
       return {
         ...state,
         isLoaded: true,
-        isEmpty: true
+        isEmpty: true,
+        organizations: []
       };
 
     default:


### PR DESCRIPTION
**Changes**
 
* Added `org_users` cascade delete in `deleteOrganization`  queries all docs where `org_handle` matches and deletes them in parallel via `Promise.all`
* Removed `useFirebase()` call from inside the action `firebase` is now passed in as an argument like the rest of the action creators
* Added `getProfileData()` call in `OrgDeleteModal` after deletion so Redux profile state reflects the removed org before redirecting
* Added `useFirestore` hook and `firestore` to the `useCallback` dependency array accordingly
* Consolidated import of `deleteOrganization` and `getProfileData` from the unified actions index instead of the specific `orgActions` file

Fixes #429 