### PR TITLE
fix: return docref.id from addComment action

### DIFF
--- a/src/store/actions/tutorialPageActions.js
+++ b/src/store/actions/tutorialPageActions.js
@@ -218,6 +218,7 @@ export const addComment = comment => async (firebase, firestore, dispatch) => {
     }
 
     dispatch({ type: actions.ADD_COMMENT_SUCCESS });
+    return docref.id
   } catch (e) {
     dispatch({ type: actions.ADD_COMMENT_FAILED, payload: e.message });
   }


### PR DESCRIPTION
 
**Changes**
 
* Added `return docref.id` after `ADD_COMMENT_SUCCESS` dispatch in `addComment` the calling component was already capturing and using this value to update local state, it just wasn't being returned

Fixes #431 