### PR TITLE
fix: use docs.map instead of forEach in ViewOrganization querySnapshot

### DIFF
--- a/src/components/Organization/ViewOrganization/index.jsx
+++ b/src/components/Organization/ViewOrganization/index.jsx
@@ -111,7 +111,7 @@ const ViewOrganization = () => {
       .where("org_handle", "==", handle)
       .get()
       .then(querySnapshot => {
-        setPeople(querySnapshot.forEach(doc => doc.data()));
+        setPeople(querySnapshot.docs.map(doc => doc.data()));
       });
   }, [db, handle]);
 
@@ -120,7 +120,7 @@ const ViewOrganization = () => {
       .where("uid", "==", profileData.uid)
       .get()
       .then(querySnapshot => {
-        setOrgFollowed(querySnapshot.forEach(doc => doc.data()));
+        setOrgFollowed(querySnapshot.docs.map(doc => doc.data()));
       });
   }, [db, profileData.uid]);
 


### PR DESCRIPTION
**Changes**
 
* Changed `setPeople(querySnapshot.forEach(doc => doc.data()))` to `setPeople(querySnapshot.docs.map(doc => doc.data()))`
* Same fix for `setOrgFollowed` both now correctly receive an array of document data

Fixes #433 
